### PR TITLE
Update README.md with higher mvn version for sdk11

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ XSK stack can run within the HANA box, also in the virtual HANA system or outsid
 
 Prerequisites:
 - Java 11 or later
-- Maven 3.5.0 or later
+- Maven 3.6.2 or later
 ```
 mvn clean install
 ```


### PR DESCRIPTION
Closes sap/fundamental#


With proper **jdk 11** installation(e.g. setting of system variables, paths ,etc), and **maven 3.5.4** previously installed, project build was **failing** due incompatibility between maven-compiler-plugin and its target version:
`<maven.compiler.target>11</maven.compiler.target>`. Upgrading mvn version to 3.6.2 or higher resolves the issue.

#### Changelog

**Changed**

* Changed mvn version in README.md.


