### PR TITLE
HDBTable itests against PostgreSQL&MySQL

### DIFF
--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityAlterProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityAlterProcessor.java
@@ -68,11 +68,7 @@ public class XSKEntityAlterProcessor {
 
     // ADD iteration
     for (XSKDataStructureHDBTableColumnModel columnModel : entityModel.getColumns()) {
-<<<<<<< HEAD
-      String name = XSKHDBUtils.escapeArtifactName(columnModel.getName());
-=======
       String name = XSKHDBUtils.escapeArtifactName(connection, columnModel.getName());
->>>>>>> 7df2f63 (refactored XSKHDBUtils)
       DataType type = DataType.valueOf(columnModel.getType());
       String length = columnModel.getLength();
       boolean isNullable = columnModel.isNullable();

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityAlterProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityAlterProcessor.java
@@ -68,7 +68,11 @@ public class XSKEntityAlterProcessor {
 
     // ADD iteration
     for (XSKDataStructureHDBTableColumnModel columnModel : entityModel.getColumns()) {
+<<<<<<< HEAD
       String name = XSKHDBUtils.escapeArtifactName(columnModel.getName());
+=======
+      String name = XSKHDBUtils.escapeArtifactName(connection, columnModel.getName());
+>>>>>>> 7df2f63 (refactored XSKHDBUtils)
       DataType type = DataType.valueOf(columnModel.getType());
       String length = columnModel.getLength();
       boolean isNullable = columnModel.isNullable();

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityCreateProcessor.java
@@ -42,13 +42,21 @@ public class XSKEntityCreateProcessor extends AbstractXSKProcessor<XSKDataStruct
    * @throws SQLException the SQL exception
    */
   public void execute(Connection connection, XSKDataStructureEntityModel entityModel) throws SQLException {
+<<<<<<< HEAD
     String tableName = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel));
+=======
+    String tableName = XSKHDBUtils.escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel));
+>>>>>>> 7df2f63 (refactored XSKHDBUtils)
     logger.info("Processing Create Table: {}", tableName);
     CreateTableBuilder createTableBuilder = SqlFactory.getNative(connection).create().table(tableName);
     List<XSKDataStructureHDBTableColumnModel> columns = entityModel.getColumns();
     List<String> primaryKeyColumns = new ArrayList<String>();
     for (XSKDataStructureHDBTableColumnModel columnModel : columns) {
+<<<<<<< HEAD
       String name = XSKHDBUtils.escapeArtifactName(columnModel.getName());
+=======
+      String name = XSKHDBUtils.escapeArtifactName(connection, columnModel.getName());
+>>>>>>> 7df2f63 (refactored XSKHDBUtils)
       DataType type = DataType.valueOf(columnModel.getType());
       String length = columnModel.getLength();
       boolean isNullable = columnModel.isNullable();
@@ -96,6 +104,7 @@ public class XSKEntityCreateProcessor extends AbstractXSKProcessor<XSKDataStruct
         for (XSKDataStructureHDBTableConstraintForeignKeyModel foreignKey : entityModel.getConstraints().getForeignKeys()) {
           String foreignKeyName = "FK_" + foreignKey.getName();
           String[] fkColumns = foreignKey.getColumns();
+<<<<<<< HEAD
           String referencedTable = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel, foreignKey.getReferencedTable()));
           String[] referencedColumns = foreignKey.getReferencedColumns();
           foreignKeyName = XSKHDBUtils.escapeArtifactName(foreignKeyName);
@@ -104,6 +113,17 @@ public class XSKEntityCreateProcessor extends AbstractXSKProcessor<XSKDataStruct
           }
           for (int i = 0; i < referencedColumns.length; i++) {
             referencedColumns[i] = XSKHDBUtils.escapeArtifactName(referencedColumns[i]);
+=======
+          String referencedTable = XSKHDBUtils
+              .escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel, foreignKey.getReferencedTable()));
+          String[] referencedColumns = foreignKey.getReferencedColumns();
+          foreignKeyName = XSKHDBUtils.escapeArtifactName(connection, foreignKeyName);
+          for (int i = 0; i < fkColumns.length; i++) {
+            fkColumns[i] = XSKHDBUtils.escapeArtifactName(connection, fkColumns[i]);
+          }
+          for (int i = 0; i < referencedColumns.length; i++) {
+            referencedColumns[i] = XSKHDBUtils.escapeArtifactName(connection, referencedColumns[i]);
+>>>>>>> 7df2f63 (refactored XSKHDBUtils)
           }
           createTableBuilder.foreignKey(foreignKeyName, fkColumns, referencedTable, referencedColumns);
         }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityCreateProcessor.java
@@ -42,21 +42,13 @@ public class XSKEntityCreateProcessor extends AbstractXSKProcessor<XSKDataStruct
    * @throws SQLException the SQL exception
    */
   public void execute(Connection connection, XSKDataStructureEntityModel entityModel) throws SQLException {
-<<<<<<< HEAD
-    String tableName = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel));
-=======
     String tableName = XSKHDBUtils.escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel));
->>>>>>> 7df2f63 (refactored XSKHDBUtils)
     logger.info("Processing Create Table: {}", tableName);
     CreateTableBuilder createTableBuilder = SqlFactory.getNative(connection).create().table(tableName);
     List<XSKDataStructureHDBTableColumnModel> columns = entityModel.getColumns();
     List<String> primaryKeyColumns = new ArrayList<String>();
     for (XSKDataStructureHDBTableColumnModel columnModel : columns) {
-<<<<<<< HEAD
-      String name = XSKHDBUtils.escapeArtifactName(columnModel.getName());
-=======
       String name = XSKHDBUtils.escapeArtifactName(connection, columnModel.getName());
->>>>>>> 7df2f63 (refactored XSKHDBUtils)
       DataType type = DataType.valueOf(columnModel.getType());
       String length = columnModel.getLength();
       boolean isNullable = columnModel.isNullable();
@@ -104,16 +96,6 @@ public class XSKEntityCreateProcessor extends AbstractXSKProcessor<XSKDataStruct
         for (XSKDataStructureHDBTableConstraintForeignKeyModel foreignKey : entityModel.getConstraints().getForeignKeys()) {
           String foreignKeyName = "FK_" + foreignKey.getName();
           String[] fkColumns = foreignKey.getColumns();
-<<<<<<< HEAD
-          String referencedTable = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel, foreignKey.getReferencedTable()));
-          String[] referencedColumns = foreignKey.getReferencedColumns();
-          foreignKeyName = XSKHDBUtils.escapeArtifactName(foreignKeyName);
-          for (int i = 0; i < fkColumns.length; i++) {
-            fkColumns[i] = XSKHDBUtils.escapeArtifactName(fkColumns[i]);
-          }
-          for (int i = 0; i < referencedColumns.length; i++) {
-            referencedColumns[i] = XSKHDBUtils.escapeArtifactName(referencedColumns[i]);
-=======
           String referencedTable = XSKHDBUtils
               .escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel, foreignKey.getReferencedTable()));
           String[] referencedColumns = foreignKey.getReferencedColumns();
@@ -123,7 +105,6 @@ public class XSKEntityCreateProcessor extends AbstractXSKProcessor<XSKDataStruct
           }
           for (int i = 0; i < referencedColumns.length; i++) {
             referencedColumns[i] = XSKHDBUtils.escapeArtifactName(connection, referencedColumns[i]);
->>>>>>> 7df2f63 (refactored XSKHDBUtils)
           }
           createTableBuilder.foreignKey(foreignKeyName, fkColumns, referencedTable, referencedColumns);
         }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityDropProcessor.java
@@ -39,7 +39,7 @@ public class XSKEntityDropProcessor extends AbstractXSKProcessor<XSKDataStructur
    * @throws SQLException the SQL exception
    */
   public void execute(Connection connection, XSKDataStructureEntityModel entityModel) throws SQLException {
-    String tableName = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel));
+    String tableName = XSKHDBUtils.escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel));
     logger.info("Processing Drop Table: {}", tableName);
     if (SqlFactory.getNative(connection).exists(connection, tableName)) {
       String sql = SqlFactory.getNative(connection).select().column("COUNT(*)").from(tableName)
@@ -67,12 +67,12 @@ public class XSKEntityDropProcessor extends AbstractXSKProcessor<XSKDataStructur
           String[] fkColumns = foreignKey.getColumns();
           String referencedTable = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel, foreignKey.getReferencedTable()));
           String[] referencedColumns = foreignKey.getReferencedColumns();
-          foreignKeyName = XSKHDBUtils.escapeArtifactName(foreignKeyName);
+          foreignKeyName = XSKHDBUtils.escapeArtifactName(connection, foreignKeyName);
           for (int i = 0; i < fkColumns.length; i++) {
-            fkColumns[i] = XSKHDBUtils.escapeArtifactName(fkColumns[i]);
+            fkColumns[i] = XSKHDBUtils.escapeArtifactName(connection, fkColumns[i]);
           }
           for (int i = 0; i < referencedColumns.length; i++) {
-            referencedColumns[i] = XSKHDBUtils.escapeArtifactName(referencedColumns[i]);
+            referencedColumns[i] = XSKHDBUtils.escapeArtifactName(connection, referencedColumns[i]);
           }
           sql = SqlFactory.getNative(connection).drop().constraint(foreignKeyName).fromTable(tableName).build();
           executeSql(sql, connection);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityDropProcessor.java
@@ -65,7 +65,6 @@ public class XSKEntityDropProcessor extends AbstractXSKProcessor<XSKDataStructur
         for (XSKDataStructureHDBTableConstraintForeignKeyModel foreignKey : entityModel.getConstraints().getForeignKeys()) {
           String foreignKeyName = "FK_" + foreignKey.getName();
           String[] fkColumns = foreignKey.getColumns();
-          String referencedTable = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel, foreignKey.getReferencedTable()));
           String[] referencedColumns = foreignKey.getReferencedColumns();
           foreignKeyName = XSKHDBUtils.escapeArtifactName(connection, foreignKeyName);
           for (int i = 0; i < fkColumns.length; i++) {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityForeignKeysProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityForeignKeysProcessor.java
@@ -50,7 +50,7 @@ public class XSKEntityForeignKeysProcessor extends AbstractXSKProcessor<XSKDataS
 
       String sourceTable = XSKHDBUtils.getTableName(entityModel);
       String name = "FK_" + sourceTable + "_" + tableName;
-      sourceTable = XSKHDBUtils.escapeArtifactName(sourceTable);
+      sourceTable = XSKHDBUtils.escapeArtifactName(connection, sourceTable);
 
       boolean existing = SqlFactory.getNative(connection).exists(connection, sourceTable);
       if (existing) {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityUpdateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityUpdateProcessor.java
@@ -42,7 +42,7 @@ public class XSKEntityUpdateProcessor extends AbstractXSKProcessor<XSKDataStruct
    * @throws SQLException the SQL exception
    */
   public void execute(Connection connection, XSKDataStructureEntityModel entityModel) throws SQLException {
-    String tableName = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel));
+    String tableName = XSKHDBUtils.escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel));
     logger.info("Processing Update Entity: {}", tableName);
     if (SqlFactory.getNative(connection).exists(connection, tableName)) {
       if (SqlFactory.getNative(connection).count(connection, tableName) == 0) {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbprocedure/HDBProcedureCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbprocedure/HDBProcedureCreateProcessor.java
@@ -11,10 +11,6 @@
  */
 package com.sap.xsk.hdb.ds.processors.hdbprocedure;
 
-<<<<<<< HEAD
-=======
-
->>>>>>> 7df2f63 (refactored XSKHDBUtils)
 import static java.text.MessageFormat.format;
 
 import com.sap.xsk.hdb.ds.model.hdbprocedure.XSKDataStructureHDBProcedureModel;

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbprocedure/HDBProcedureCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbprocedure/HDBProcedureCreateProcessor.java
@@ -11,6 +11,10 @@
  */
 package com.sap.xsk.hdb.ds.processors.hdbprocedure;
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> 7df2f63 (refactored XSKHDBUtils)
 import static java.text.MessageFormat.format;
 
 import com.sap.xsk.hdb.ds.model.hdbprocedure.XSKDataStructureHDBProcedureModel;
@@ -31,7 +35,7 @@ public class HDBProcedureCreateProcessor extends AbstractXSKProcessor<XSKDataStr
   public void execute(Connection connection, XSKDataStructureHDBProcedureModel hdbProcedure) throws SQLException {
     logger.info("Processing Create Procedure: " + hdbProcedure.getName());
 
-    String procedureName = XSKHDBUtils.escapeArtifactName(hdbProcedure.getName());
+    String procedureName = XSKHDBUtils.escapeArtifactName(connection, hdbProcedure.getName());
     if (!SqlFactory.getNative(connection).exists(connection, procedureName, DatabaseArtifactTypes.PROCEDURE)) {
       String sql = XSKConstants.XSK_HDBPROCEDURE_CREATE + hdbProcedure.getContent();
       executeSql(sql, connection);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbprocedure/HDBProcedureDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbprocedure/HDBProcedureDropProcessor.java
@@ -31,7 +31,7 @@ public class HDBProcedureDropProcessor extends AbstractXSKProcessor<XSKDataStruc
   public void execute(Connection connection, XSKDataStructureHDBProcedureModel hdbProcedure) throws SQLException {
     logger.info("Processing Drop Procedure: " + hdbProcedure.getName());
 
-    String procedureName = XSKHDBUtils.escapeArtifactName(hdbProcedure.getName());
+    String procedureName = XSKHDBUtils.escapeArtifactName(connection, hdbProcedure.getName());
     if (SqlFactory.getNative(connection).exists(connection, procedureName, DatabaseArtifactTypes.PROCEDURE)) {
       String sql = XSKConstants.XSK_HDBPROCEDURE_DROP + hdbProcedure.getName();
       executeSql(sql, connection);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbtablefunction/HDBTableFunctionCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbtablefunction/HDBTableFunctionCreateProcessor.java
@@ -31,7 +31,7 @@ public class HDBTableFunctionCreateProcessor extends AbstractXSKProcessor<XSKDat
   public void execute(Connection connection, XSKDataStructureHDBTableFunctionModel hdbTableFunction) throws SQLException {
     logger.info("Processing Create TableFunction: " + hdbTableFunction.getName());
 
-    String tableFunctionName = XSKHDBUtils.escapeArtifactName(hdbTableFunction.getName());
+    String tableFunctionName = XSKHDBUtils.escapeArtifactName(connection, hdbTableFunction.getName());
     if (!SqlFactory.getNative(connection).exists(connection, tableFunctionName, DatabaseArtifactTypes.FUNCTION)) {
       String sql = XSKConstants.XSK_HDBTABLEFUNCTION_CREATE + hdbTableFunction.getContent();
       executeSql(sql, connection);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbtablefunction/HDBTableFunctionDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbtablefunction/HDBTableFunctionDropProcessor.java
@@ -31,7 +31,7 @@ public class HDBTableFunctionDropProcessor extends AbstractXSKProcessor<XSKDataS
   public void execute(Connection connection, XSKDataStructureHDBTableFunctionModel hdbTableFunction) throws SQLException {
     logger.info("Processing Drop TableFunction: " + hdbTableFunction.getName());
 
-    String tableFunctionName = XSKHDBUtils.escapeArtifactName(hdbTableFunction.getName());
+    String tableFunctionName = XSKHDBUtils.escapeArtifactName(connection, hdbTableFunction.getName());
     if (SqlFactory.getNative(connection).exists(connection, tableFunctionName, DatabaseArtifactTypes.FUNCTION)) {
       String sql = XSKConstants.XSK_HDBTABLEFUNCTION_DROP + hdbTableFunction.getName();
       executeSql(sql, connection);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymCreateProcessor.java
@@ -40,8 +40,9 @@ public class HDBSynonymCreateProcessor extends AbstractXSKProcessor<XSKDataStruc
   public void execute(Connection connection, XSKDataStructureHDBSynonymModel synonymModel) throws SQLException {
     logger.info("Processing Create Synonym: " + synonymModel.getName());
 
-    String synonymName = XSKHDBUtils.escapeArtifactName(synonymModel.getName());
-    String targetObjectName = XSKHDBUtils.escapeArtifactName(synonymModel.getTargetObject(), synonymModel.getTargetSchema());
+    String synonymName = XSKHDBUtils.escapeArtifactName(connection, synonymModel.getName());
+    String targetObjectName = XSKHDBUtils
+        .escapeArtifactName(connection, synonymModel.getTargetObject(), synonymModel.getTargetSchema());
     if (!SqlFactory.getNative(connection).exists(connection, synonymModel.getName(), DatabaseArtifactTypes.SYNONYM)) {
       String sql = SqlFactory.getNative(connection).create().synonym(synonymName).forSource(targetObjectName).build();
       executeSql(sql, connection);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymDropProcessor.java
@@ -39,7 +39,7 @@ public class HDBSynonymDropProcessor extends AbstractXSKProcessor<XSKDataStructu
   public void execute(Connection connection, XSKDataStructureHDBSynonymModel synonymModel) throws SQLException {
     logger.info("Processing Drop Synonym: " + synonymModel.getName());
 
-    String synonymName = XSKHDBUtils.escapeArtifactName(synonymModel.getName());
+    String synonymName = XSKHDBUtils.escapeArtifactName(connection, synonymModel.getName());
     if (SqlFactory.getNative(connection).exists(connection, synonymName, DatabaseArtifactTypes.SYNONYM)) {
       String sql = SqlFactory.getNative(connection).drop().synonym(synonymName).build();
       executeSql(sql, connection);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/XSKTableCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/XSKTableCreateProcessor.java
@@ -28,6 +28,7 @@ import org.eclipse.dirigible.database.sql.DataType;
 import org.eclipse.dirigible.database.sql.ISqlKeywords;
 import org.eclipse.dirigible.database.sql.SqlFactory;
 import org.eclipse.dirigible.database.sql.builders.table.CreateTableBuilder;
+import org.eclipse.dirigible.database.sql.dialects.postgres.PostgresSqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/XSKTableDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/XSKTableDropProcessor.java
@@ -41,7 +41,7 @@ public class XSKTableDropProcessor extends AbstractXSKProcessor<XSKDataStructure
    * @throws SQLException the SQL exception
    */
   public void execute(Connection connection, XSKDataStructureHDBTableModel tableModel) throws SQLException {
-    String tableName = XSKHDBUtils.escapeArtifactName(tableModel.getName());
+    String tableName = XSKHDBUtils.escapeArtifactName(connection, tableModel.getName());
     logger.info("Processing Drop Table: " + tableName);
     if (SqlFactory.getNative(connection).exists(connection, tableName)) {
       String sql = null;

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/view/XSKViewCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/view/XSKViewCreateProcessor.java
@@ -41,7 +41,7 @@ public class XSKViewCreateProcessor extends AbstractXSKProcessor<XSKDataStructur
   public void execute(Connection connection, XSKDataStructureHDBViewModel viewModel) throws SQLException {
     logger.info("Processing Create View: " + viewModel.getName());
 
-    String viewName = XSKHDBUtils.escapeArtifactName(viewModel.getName());
+    String viewName = XSKHDBUtils.escapeArtifactName(connection, viewModel.getName());
     if (!SqlFactory.getNative(connection).exists(connection, viewName, DatabaseArtifactTypes.VIEW)) {
       String sql = null;
       switch (viewModel.getHanaVersion()) {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/view/XSKViewDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/view/XSKViewDropProcessor.java
@@ -40,7 +40,7 @@ public class XSKViewDropProcessor extends AbstractXSKProcessor<XSKDataStructureH
   public void execute(Connection connection, XSKDataStructureHDBViewModel viewModel) throws SQLException {
     logger.info("Processing Drop View: " + viewModel.getName());
 
-    String viewName = XSKHDBUtils.escapeArtifactName(viewModel.getName());
+    String viewName = XSKHDBUtils.escapeArtifactName(connection, viewModel.getName());
     if (SqlFactory.getNative(connection).exists(connection, viewName, DatabaseArtifactTypes.VIEW)) {
       String sql = SqlFactory.getNative(connection).drop().view(viewName).build();
       executeSql(sql, connection);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/service/manager/IXSKEntityManagerService.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/service/manager/IXSKEntityManagerService.java
@@ -84,7 +84,7 @@ public class IXSKEntityManagerService extends AbstractDataStructureManagerServic
   public void createDataStructure(Connection connection, XSKDataStructureEntitiesModel entitiesModel) throws SQLException {
     if (entitiesModel != null) {
       for (XSKDataStructureEntityModel entityModel : entitiesModel.getContext().getЕntities()) {
-        String tableName = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel));
+        String tableName = XSKHDBUtils.escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel));
         if (!SqlFactory.getNative(connection).exists(connection, tableName)) {
           this.xskEntityCreateProcessor.execute(connection, entityModel);
         } else {
@@ -99,7 +99,7 @@ public class IXSKEntityManagerService extends AbstractDataStructureManagerServic
   public void dropDataStructure(Connection connection, XSKDataStructureEntitiesModel entitiesModel) throws SQLException {
     if (entitiesModel != null) {
       for (XSKDataStructureEntityModel entityModel : entitiesModel.getContext().getЕntities()) {
-        String tableName = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel));
+        String tableName = XSKHDBUtils.escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel));
         if (SqlFactory.getNative(connection).exists(connection, tableName)) {
           if (SqlFactory.getNative(connection).count(connection, tableName) == 0) {
             xskEntityDropProcessor.execute(connection, entityModel);
@@ -116,7 +116,7 @@ public class IXSKEntityManagerService extends AbstractDataStructureManagerServic
       throws SQLException, OperationNotSupportedException {
     if (entitiesModel != null) {
       for (XSKDataStructureEntityModel entityModel : entitiesModel.getContext().getЕntities()) {
-        String tableName = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel));
+        String tableName = XSKHDBUtils.escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel));
         if (SqlFactory.getNative(connection).exists(connection, tableName)) {
           if (SqlFactory.getNative(connection).count(connection, tableName) != 0) {
             this.xskEntityUpdateProcessor.execute(connection, entityModel);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/utils/XSKHDBUtils.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/utils/XSKHDBUtils.java
@@ -12,11 +12,14 @@
 package com.sap.xsk.utils;
 
 import com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureEntityModel;
+import java.sql.Connection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.database.ds.model.IDataStructureModel;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.dialects.mysql.MySQLSqlDialect;
 
 public class XSKHDBUtils {
 
@@ -103,9 +106,9 @@ public class XSKHDBUtils {
     }
 
     if (schemaName != null && !schemaName.trim().isEmpty()) {
-      if (!schemaName.startsWith("\"")) {
+      if (!schemaName.startsWith(escapeSymbol)) {
         if (caseSensitive) {
-          schemaName = "\"" + schemaName + "\"" + ".";
+          schemaName = escapeSymbol + schemaName + escapeSymbol + ".";
         } else {
           schemaName = schemaName + ".";
         }
@@ -124,5 +127,9 @@ public class XSKHDBUtils {
     return escapeArtifactName(connection, artifactName, null);
   }
 
-
+  public static String getEscapeSymbol(Connection connection) {
+    return (SqlFactory.deriveDialect(connection).getClass().equals(MySQLSqlDialect.class))
+        ? "`"
+        : "\"";
+  }
 }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/utils/XSKHDBUtils.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/utils/XSKHDBUtils.java
@@ -95,13 +95,11 @@ public class XSKHDBUtils {
    * @param schemaName   name of teh schema that will be assembled to the artifact name
    * @return escaped in quotes artifact name
    */
-  public static String escapeArtifactName(String artifactName, String schemaName) {
-    boolean caseSensitive = Boolean.parseBoolean(Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false"));
-
-    if (!artifactName.startsWith("\"")) {
-      if (caseSensitive) {
-        artifactName = "\"" + artifactName + "\"";
-      }
+  public static String escapeArtifactName(Connection connection, String artifactName, String schemaName) {
+    boolean caseSensitive = Boolean.parseBoolean(Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "true"));
+    String escapeSymbol = getEscapeSymbol(connection);
+    if (!artifactName.startsWith(escapeSymbol)) {
+      artifactName = escapeSymbol + artifactName + escapeSymbol;
     }
 
     if (schemaName != null && !schemaName.trim().isEmpty()) {
@@ -120,10 +118,10 @@ public class XSKHDBUtils {
   }
 
   /**
-   * See also {@link #escapeArtifactName(String, String)}.
+   * See also {@link #escapeArtifactName(Connection, String, String)}.
    */
-  public static String escapeArtifactName(String artifactName) {
-    return escapeArtifactName(artifactName, null);
+  public static String escapeArtifactName(Connection connection, String artifactName) {
+    return escapeArtifactName(connection, artifactName, null);
   }
 
 

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/processors/HDBProcedureProcessorTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/processors/HDBProcedureProcessorTest.java
@@ -32,6 +32,7 @@ import org.eclipse.dirigible.core.test.AbstractGuiceTest;
 import org.eclipse.dirigible.database.ds.model.IDataStructureModel;
 import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
 import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.dialects.DefaultSqlDialect;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +51,8 @@ public class HDBProcedureProcessorTest extends AbstractGuiceTest {
   private Connection mockConnection;
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private SqlFactory mockSqlfactory;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private DefaultSqlDialect mockSqlDialect;
   @Mock
   private PreparedStatement mockStatement;
 
@@ -64,6 +67,7 @@ public class HDBProcedureProcessorTest extends AbstractGuiceTest {
     //PowerMock do not support deep stub calls
     PowerMockito.mockStatic(SqlFactory.class, Configuration.class);
     when(SqlFactory.getNative(mockConnection)).thenReturn(mockSqlfactory);
+    when(SqlFactory.deriveDialect(mockConnection)).thenReturn(mockSqlDialect);
     when(Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
 
     HDBProcedureCreateProcessor processorSpy = spy(HDBProcedureCreateProcessor.class);
@@ -88,6 +92,7 @@ public class HDBProcedureProcessorTest extends AbstractGuiceTest {
     //PowerMock do not support deep stub calls
     PowerMockito.mockStatic(SqlFactory.class, Configuration.class);
     when(SqlFactory.getNative(mockConnection)).thenReturn(mockSqlfactory);
+    when(SqlFactory.deriveDialect(mockConnection)).thenReturn(mockSqlDialect);
     when(Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
 
     HDBProcedureDropProcessor processorSpy = spy(HDBProcedureDropProcessor.class);

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/processors/HDBSynonymProcessorTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/processors/HDBSynonymProcessorTest.java
@@ -51,8 +51,8 @@ public class HDBSynonymProcessorTest extends AbstractGuiceTest {
   private Connection mockConnection;
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private SqlFactory mockSqlfactory;
-  @Mock
-  private DefaultSqlDialect mockDefaultSqlDialect;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private DefaultSqlDialect mockSqlDialect;
   @Mock
   private CreateBranchingBuilder create;
   @Mock
@@ -80,6 +80,7 @@ public class HDBSynonymProcessorTest extends AbstractGuiceTest {
     //PowerMock do not support deep stub calls
     PowerMockito.mockStatic(SqlFactory.class, Configuration.class);
     when(SqlFactory.getNative(mockConnection)).thenReturn(mockSqlfactory);
+    when(SqlFactory.deriveDialect(mockConnection)).thenReturn(mockSqlDialect);
     when(SqlFactory.getNative(mockConnection).exists(mockConnection, model.getName(), DatabaseArtifactTypes.SYNONYM)).thenReturn(false);
     when(SqlFactory.getNative(mockConnection).create()).thenReturn(create);
     when(SqlFactory.getNative(mockConnection).create().synonym(any())).thenReturn(mockCreateSynonymBuilder);
@@ -103,6 +104,7 @@ public class HDBSynonymProcessorTest extends AbstractGuiceTest {
 
     PowerMockito.mockStatic(SqlFactory.class, Configuration.class);
     when(SqlFactory.getNative(mockConnection)).thenReturn(mockSqlfactory);
+    when(SqlFactory.deriveDialect(mockConnection)).thenReturn(mockSqlDialect);
     when(SqlFactory.getNative(mockConnection).exists(mockConnection, model.getName(), DatabaseArtifactTypes.SYNONYM)).thenReturn(true);
     when(SqlFactory.getNative(mockConnection).drop()).thenReturn(drop);
     when(SqlFactory.getNative(mockConnection).drop().synonym(any())).thenReturn(mockDropSynonymBuilder);

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/processors/HDBTableFunctionProcessorTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/processors/HDBTableFunctionProcessorTest.java
@@ -32,6 +32,7 @@ import org.eclipse.dirigible.core.test.AbstractGuiceTest;
 import org.eclipse.dirigible.database.ds.model.IDataStructureModel;
 import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
 import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.dialects.DefaultSqlDialect;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +51,9 @@ public class HDBTableFunctionProcessorTest extends AbstractGuiceTest {
   private Connection mockConnection;
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private SqlFactory mockSqlfactory;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private DefaultSqlDialect mockSqlDialect;
+
   @Mock
   private PreparedStatement mockStatement;
 
@@ -63,6 +67,7 @@ public class HDBTableFunctionProcessorTest extends AbstractGuiceTest {
     //PowerMock do not support deep stub calls
     PowerMockito.mockStatic(SqlFactory.class, Configuration.class);
     when(SqlFactory.getNative(mockConnection)).thenReturn(mockSqlfactory);
+    when(SqlFactory.deriveDialect(mockConnection)).thenReturn(mockSqlDialect);
     when(Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
 
     HDBTableFunctionCreateProcessor processorSpy = spy(HDBTableFunctionCreateProcessor.class);
@@ -87,6 +92,7 @@ public class HDBTableFunctionProcessorTest extends AbstractGuiceTest {
     //PowerMock do not support deep stub calls
     PowerMockito.mockStatic(SqlFactory.class, Configuration.class);
     when(SqlFactory.getNative(mockConnection)).thenReturn(mockSqlfactory);
+    when(SqlFactory.deriveDialect(mockConnection)).thenReturn(mockSqlDialect);
     when(Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
 
     HDBTableFunctionDropProcessor processorSpy = spy(HDBTableFunctionDropProcessor.class);

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/processors/XSKViewProcessorTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/processors/XSKViewProcessorTest.java
@@ -53,8 +53,8 @@ public class XSKViewProcessorTest extends AbstractGuiceTest {
   private Connection mockConnection;
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private SqlFactory mockSqlfactory;
-  @Mock
-  private DefaultSqlDialect mockDefaultSqlDialect;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private DefaultSqlDialect mockSqlDialect;
   @Mock
   private CreateBranchingBuilder create;
   @Mock
@@ -82,6 +82,7 @@ public class XSKViewProcessorTest extends AbstractGuiceTest {
     //PowerMock do not support deep stub calls
     PowerMockito.mockStatic(SqlFactory.class, Configuration.class);
     when(SqlFactory.getNative(mockConnection)).thenReturn(mockSqlfactory);
+    when(SqlFactory.deriveDialect(mockConnection)).thenReturn(mockSqlDialect);
     when(SqlFactory.getNative(mockConnection).exists(mockConnection, model.getName(), DatabaseArtifactTypes.VIEW)).thenReturn(false);
     when(SqlFactory.getNative(mockConnection).create()).thenReturn(create);
     when(SqlFactory.getNative(mockConnection).create().view(any())).thenReturn(mockCreateViewBuilder);
@@ -106,6 +107,7 @@ public class XSKViewProcessorTest extends AbstractGuiceTest {
 
     PowerMockito.mockStatic(SqlFactory.class, Configuration.class);
     when(SqlFactory.getNative(mockConnection)).thenReturn(mockSqlfactory);
+    when(SqlFactory.deriveDialect(mockConnection)).thenReturn(mockSqlDialect);
     when(SqlFactory.getNative(mockConnection).exists(mockConnection, model.getName(), DatabaseArtifactTypes.VIEW)).thenReturn(false);
     when(Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
 
@@ -125,6 +127,7 @@ public class XSKViewProcessorTest extends AbstractGuiceTest {
 
     PowerMockito.mockStatic(SqlFactory.class, Configuration.class);
     when(SqlFactory.getNative(mockConnection)).thenReturn(mockSqlfactory);
+    when(SqlFactory.deriveDialect(mockConnection)).thenReturn(mockSqlDialect);
     when(SqlFactory.getNative(mockConnection).exists(mockConnection, model.getName(), DatabaseArtifactTypes.VIEW)).thenReturn(true);
     when(SqlFactory.getNative(mockConnection).drop()).thenReturn(drop);
     when(SqlFactory.getNative(mockConnection).drop().view(any())).thenReturn(mockDropViewBuilder);


### PR DESCRIPTION

Fixes: #176 #171

Introduced itests for HDBTable. Refactored util method for escaping artefact names. Adapted unit tests for other artefacts accordingly.
HDBTable against PostgreSQL should have its artefact properties not escaped except for the table name.