### PR TITLE
Fix 214

### DIFF
--- a/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/ds/service/XSKOData2ODataXTransformer.java
+++ b/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/ds/service/XSKOData2ODataXTransformer.java
@@ -11,166 +11,19 @@
  */
 package com.sap.xsk.xsodata.ds.service;
 
-import com.sap.xsk.parser.xsodata.model.XSKHDBXSODATAAssociation;
-import com.sap.xsk.parser.xsodata.model.XSKHDBXSODATAEntity;
-import com.sap.xsk.parser.xsodata.model.XSKHDBXSODATAHandlerMethod;
-import com.sap.xsk.xsodata.ds.model.XSKODataModel;
-import org.eclipse.dirigible.database.persistence.model.PersistenceTableColumnModel;
-import org.eclipse.dirigible.database.persistence.model.PersistenceTableModel;
-import org.eclipse.dirigible.engine.odata2.transformers.DBMetadataUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.eclipse.dirigible.engine.odata2.definition.ODataDefinition;
+import org.eclipse.dirigible.engine.odata2.transformers.OData2ODataXTransformer;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.sql.SQLException;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Singleton
 public class XSKOData2ODataXTransformer {
-
-    private static final Logger logger = LoggerFactory.getLogger(XSKOData2ODataXTransformer.class);
-
     @Inject
-    private DBMetadataUtil dbMetadataUtil;
+    private OData2ODataXTransformer oData2ODataXTransformer;
 
-    public String[] transform(XSKODataModel model) throws SQLException {
-
-        if (model.getService() == null) {
-            logger.error("Service element is null for xsodata file {}, so it will be skipped. Maybe the format is wrong and cannot be parsed.",
-                    model.getName());
-        }
-
-        String[] result = new String[2];
-        StringBuilder buff = new StringBuilder();
-        String namespace = model.getService().getNamespace() != null ? model.getService().getNamespace() : "Default";
-        buff.append("<Schema Namespace=\"").append(namespace).append("\"\n\t");
-        buff.append("xmlns=\"http://schemas.microsoft.com/ado/2008/09/edm\">\n");
-
-        StringBuilder associations = new StringBuilder();
-        StringBuilder entitySets = new StringBuilder();
-        StringBuilder associationsSets = new StringBuilder();
-        for (XSKHDBXSODATAEntity entity : model.getService().getEntities()) {
-            String tableName = entity.getRepositoryObject().getCatalogObjectName();
-            String entitySetName = entity.getAlias();
-
-            PersistenceTableModel tableMetadata = dbMetadataUtil.getTableMetadata(tableName);
-            //Views don't have primary keys or indexes
-            List<PersistenceTableColumnModel> idColumns = tableMetadata.getColumns().stream().filter(PersistenceTableColumnModel::isPrimaryKey)
-                    .collect(Collectors.toList());
-
-            // entity.getKeyList() can not exist for a table object.
-            if (idColumns.isEmpty() && entity.getKeyList().isEmpty() && tableMetadata.getColumns().isEmpty()) {
-                logger.error("Table {} not available for entity {}, so it will be skipped.", tableName, entitySetName);
-                continue;
-            }
-
-            buff.append("\t<EntityType Name=\"").append(entitySetName).append("Type\"");
-            if (entity.getAggregationType() != null) {
-                buff.append(" sap:semantics=\"aggregate\"");
-            }
-            buff.append(">\n");
-            buff.append("\t\t<Key>\n");
-            if (!entity.getKeyList().isEmpty()) {
-                entity.getKeyList().forEach(key -> buff.append("\t\t\t<PropertyRef Name=\"").append(key).append("\" />\n"));
-            } else if (entity.getKeyGenerated() != null) {
-                buff.append("\t\t\t<PropertyRef Name=\"").append(entity.getKeyGenerated()).append("\" />\n");
-            } else {
-                idColumns.forEach(column -> buff.append("\t\t\t<PropertyRef Name=\"").append(column.getName()).append("\" />\n"));
-            }
-
-            buff.append("\t\t</Key>\n");
-            if (entity.getKeyGenerated() != null) {
-                buff.append("\t\t<Property Name=\"").append(entity.getKeyGenerated()).append("\"").append(" Type=\"").append("Edm.String").append("\"").append(" Nullable=\"").append("false").append("\" MaxLength=\"2147483647\"").append(" sap:filterable=\"false\"").append("/>\n");
-            }
-            if (!entity.getWithPropertyProjections().isEmpty()) {
-                entity.getWithPropertyProjections().forEach(prop -> {
-                    if (tableMetadata.getColumns().stream().anyMatch(x -> x.getName().equals(prop))) {
-                        PersistenceTableColumnModel column = tableMetadata.getColumns().stream().filter(x -> x.getName().equals(prop)).findAny().get();
-                        buff.append("\t\t<Property Name=\"").append(prop).append("\"").append(" Type=\"").append(column.getType()).append("\"").append(" Nullable=\"").append(column.isNullable()).append("\"/>\n");
-                    }
-                });
-            } else if (!entity.getWithoutPropertyProjections().isEmpty()) {
-                entity.getWithoutPropertyProjections().forEach(prop -> tableMetadata.getColumns().forEach(column ->
-                {
-                    if (!column.getName().equals(prop)) {
-                        buff.append("\t\t<Property Name=\"").append(column.getName()).append("\"").append(" Type=\"").append(column.getType()).append("\"").append(" Nullable=\"").append(column.isNullable()).append("\"/>\n");
-                    }
-                }));
-            } else {
-                tableMetadata.getColumns().forEach(column -> buff.append("\t\t<Property Name=\"").append(column.getName()).append("\"").append(" Type=\"").append(column.getType()).append("\"").append(" Nullable=\"").append(column.isNullable()).append("\"/>\n"));
-            }
-
-            entity.getNavigates().forEach(relation -> {
-                XSKHDBXSODATAAssociation association = XSKODataCoreService.getAssociation(model, relation.getAssociation(), relation.getAliasNavigation());
-                String toRole = association.getDependent().getEntitySetName();
-                String fromRole = association.getPrincipal().getEntitySetName();
-                buff.append("\t\t<NavigationProperty Name=\"").append(relation.getAliasNavigation()).append("\"").append(" Relationship=\"").append(getServiceNamespace(model)).append(relation.getAssociation()).append("Type\"").append(" FromRole=\"").append(fromRole).append("Principal").append("\"").append(" ToRole=\"").append(toRole).append("Dependent").append("\"/>\n");
-            });
-
-            // keep associations for later use
-            entity.getNavigates().forEach(relation -> {
-                XSKHDBXSODATAAssociation association = XSKODataCoreService.getAssociation(model, relation.getAssociation(), relation.getAliasNavigation());
-                String fromRole = association.getPrincipal().getEntitySetName();
-                String toRole = association.getDependent().getEntitySetName();
-                String fromMultiplicity = association.getPrincipal().getMultiplicityType().getText();
-                String toMultiplicity = association.getDependent().getMultiplicityType().getText();
-                associations.append("\t<Association Name=\"").append(relation.getAssociation()).append("Type\">\n").append("\t\t<End Type=\"").append(getServiceNamespace(model)).append(fromRole).append("Type\"").append(" Role=\"").append(fromRole).append("Principal").append("\" Multiplicity=\"").append(fromMultiplicity).append("\"/>\n").append(" \t\t<End Type=\"").append(getServiceNamespace(model)).append(toRole).append("Type\"").append(" Role=\"").append(toRole).append("Dependent").append("\" Multiplicity=\"").append(toMultiplicity).append("\"/>\n");
-                if (association.isWithReferentialConstraint()) {
-                    associations.append("\t<ReferentialConstraint>\n");
-                    associations.append("\t\t<Principal Role=\"").append(fromRole).append("Principal\">\n");
-                    association.getPrincipal().getBindingRole().getKeys().forEach(key -> associations.append("\t\t\t<PropertyRef Name=\"").append(key).append("\"/>\n"));
-                    associations.append("\t\t</Principal>\n");
-                    associations.append("\t\t<Dependent Role=\"").append(toRole).append("Dependent\">\n");
-                    association.getDependent().getBindingRole().getKeys().forEach(key -> associations.append("\t\t\t<PropertyRef Name=\"").append(key).append("\"/>\n"));
-                    associations.append("\t\t</Dependent>\n");
-                    associations.append("\t</ReferentialConstraint>\n");
-                }
-                associations.append("\t</Association>\n");
-            });
-
-            // keep entity sets for later use
-            entitySets.append("\t\t<EntitySet Name=\"").append(entitySetName).append("\" EntityType=\"").append(getServiceNamespace(model)).append(entitySetName).append("Type\"");
-            entity.getModifications().forEach(event -> {
-                if (event.getMethod().equals(XSKHDBXSODATAHandlerMethod.CREATE) && event.getSpecification().isForbidden()) {
-                    entitySets.append(" sap:creatable=\"false\"");
-                }
-                if (event.getMethod().equals(XSKHDBXSODATAHandlerMethod.UPDATE) && event.getSpecification().isForbidden()) {
-                    entitySets.append(" sap:updatable=\"false\"");
-                }
-                if (event.getMethod().equals(XSKHDBXSODATAHandlerMethod.DELETE) && event.getSpecification().isForbidden()) {
-                    entitySets.append(" sap:deletable=\"false\"");
-                }
-            });
-            entitySets.append("/>\n");
-
-            // keep associations sets for later use
-            entity.getNavigates().forEach(relation -> {
-                XSKHDBXSODATAAssociation association = XSKODataCoreService.getAssociation(model, relation.getAssociation(), relation.getAliasNavigation());
-                String fromRole = association.getPrincipal().getEntitySetName();
-                String toRole = association.getDependent().getEntitySetName();
-                associationsSets.append("\t\t<AssociationSet Name=\"").append(relation.getAssociation()).append("\"").append(" Association=\"").append(getServiceNamespace(model)).append(relation.getAssociation()).append("Type\">\n").append("\t\t\t<End Role=\"").append(fromRole).append("Principal").append("\"").append(" EntitySet=\"").append(fromRole).append("\"/>\n").append("\t\t\t<End Role=\"").append(toRole).append("Dependent").append("\"").append(" EntitySet=\"").append(toRole).append("\"/>\n").append("\t\t</AssociationSet>\n");
-            });
-            buff.append("\t</EntityType>\n");
-        }
-
-        buff.append(associations.toString());
-
-        StringBuilder container = new StringBuilder();
-        container.append(entitySets.toString());
-        container.append(associationsSets.toString());
-        buff.append("</Schema>\n");
-
-        result[0] = buff.toString();
-        result[1] = container.toString();
-        return result;
-    }
-
-    private String getServiceNamespace(XSKODataModel model) {
-        if (model.getService().getNamespace() != null) {
-            return model.getService().getNamespace() + ".";
-        }
-        return "";
+    public String[] transform(ODataDefinition oDataDefinition) throws SQLException {
+        return oData2ODataXTransformer.transform(oDataDefinition);
     }
 }

--- a/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/ds/synchronizer/XSKODataSynchronizer.java
+++ b/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/ds/synchronizer/XSKODataSynchronizer.java
@@ -173,8 +173,6 @@ public class XSKODataSynchronizer extends AbstractSynchronizer {
 
     /**
      * Synchronize predelivered.
-     *
-     * @throws SynchronizationException the synchronization exception
      */
     private void synchronizePredelivered() {
         logger.trace("Synchronizing predelivered XSOData...");
@@ -322,7 +320,7 @@ public class XSKODataSynchronizer extends AbstractSynchronizer {
                 Configuration.set(DBMetadataUtil.DIRIGIBLE_GENERATE_PRETTY_NAMES, "false");
                 ODataDefinition oDataDefinition = XSKODataUtils.convertXSKODataModelToODataDefinition(model, dbMetadataUtil);
 
-                String[] odataxc = generateODataX(model);
+                String[] odataxc = generateODataX(oDataDefinition);
                 String odatax = odataxc[0];
                 String odatac = odataxc[1];
                 odataCoreService.createSchema(model.getLocation(), odatax.getBytes());
@@ -353,8 +351,8 @@ public class XSKODataSynchronizer extends AbstractSynchronizer {
         }
     }
 
-    private String[] generateODataX(XSKODataModel model) throws SQLException {
-        return xskOData2ODataXTransformer.transform(model);
+    private String[] generateODataX(ODataDefinition oDataDefinition) throws SQLException {
+        return xskOData2ODataXTransformer.transform(oDataDefinition);
     }
 
     private String[] generateODataMs(ODataDefinition oDataDefinition) throws SQLException {

--- a/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/utils/XSKODataUtils.java
+++ b/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/utils/XSKODataUtils.java
@@ -14,6 +14,7 @@ package com.sap.xsk.xsodata.utils;
 import com.sap.xsk.parser.xsodata.model.XSKHDBXSODATAAssociation;
 import com.sap.xsk.parser.xsodata.model.XSKHDBXSODATAEntity;
 import com.sap.xsk.parser.xsodata.model.XSKHDBXSODATAEventType;
+import com.sap.xsk.parser.xsodata.model.XSKHDBXSODATAMultiplicityType;
 import com.sap.xsk.xsodata.ds.model.XSKODataModel;
 import com.sap.xsk.xsodata.ds.service.XSKOData2TransformerException;
 import com.sap.xsk.xsodata.ds.service.XSKODataCoreService;
@@ -65,14 +66,21 @@ public class XSKODataUtils {
                 ODataAssiciationEndDefinition fromDef = new ODataAssiciationEndDefinition();
                 fromDef.setEntity(xsOdataAssoc.getPrincipal().getEntitySetName());
 
+                //The Multiplicity of the Principal role must be 1 or 0..1
                 validateEdmMultiplicity(xsOdataAssoc.getPrincipal().getMultiplicityType().getText(), navigate.getAssociation());
                 fromDef.setMultiplicity(xsOdataAssoc.getPrincipal().getMultiplicityType().getText());
                 fromDef.setProperty((ArrayList<String>) xsOdataAssoc.getPrincipal().getBindingRole().getKeys());
                 ODataAssiciationEndDefinition toDef = new ODataAssiciationEndDefinition();
                 toDef.setEntity(xsOdataAssoc.getDependent().getEntitySetName());
 
-                validateEdmMultiplicity(xsOdataAssoc.getDependent().getMultiplicityType().getText(), navigate.getAssociation());
-                toDef.setMultiplicity(xsOdataAssoc.getDependent().getMultiplicityType().getText());
+                //The Multiplicity of the Principal role must be 1, 0..1, 1..*, *
+                //convert 1..* to *, because odata do not support it
+                if(xsOdataAssoc.getDependent().getMultiplicityType().getText().equals(XSKHDBXSODATAMultiplicityType.ONE_TO_MANY.getText())){
+                    toDef.setMultiplicity(EdmMultiplicity.MANY.toString());
+                }else{
+                    validateEdmMultiplicity(xsOdataAssoc.getDependent().getMultiplicityType().getText(), navigate.getAssociation());
+                    toDef.setMultiplicity(xsOdataAssoc.getDependent().getMultiplicityType().getText());
+                }
 
                 toDef.setProperty((ArrayList<String>) xsOdataAssoc.getDependent().getBindingRole().getKeys());
                 oDataAssociationDefinition.setFrom(fromDef);

--- a/modules/engines/engine-xsodata/src/test/java/XSKODataUtilsTest.java
+++ b/modules/engines/engine-xsodata/src/test/java/XSKODataUtilsTest.java
@@ -43,6 +43,43 @@ public class XSKODataUtilsTest {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private DBMetadataUtil dbMetadataUtil;
 
+
+    @Test
+    public void testConvertMultiplicityOneToMany() throws Exception {
+        XSKODataParser parser = new XSKODataParser();
+        String content = org.apache.commons.io.IOUtils
+                .toString(XSKODataUtilsTest.class.getResourceAsStream("/entity_multiplicity_one_to_many.xsodata"), StandardCharsets.UTF_8);
+        XSKODataModel xskoDataModel = parser.parseXSODataArtifact("np/entity_multiplicity_one_to_many.xsodata", content);
+
+        PersistenceTableColumnModel column1 = new PersistenceTableColumnModel("COMPANY_ID", "Edm.Int32", true);
+        PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("EMPLOYEE_NUMBER", "Edm.Int32", true);
+        PersistenceTableColumnModel column9 = new PersistenceTableColumnModel("ORDER_ID", "Edm.Int32", true);
+        column9.setNullable(true);
+        PersistenceTableModel model = new PersistenceTableModel("kneo.test.helloodata.CompositeKey::employee", Arrays.asList(column1, column2, column9), new ArrayList<>());
+        when(dbMetadataUtil.getTableMetadata("kneo.test.helloodata.CompositeKey::employee")).thenReturn(model);
+
+        PersistenceTableColumnModel column7 = new PersistenceTableColumnModel("ID", "Edm.Int32", true);
+        PersistenceTableColumnModel column8 = new PersistenceTableColumnModel("FK_PHONE", "Edm.Int32", false);
+        PersistenceTableRelationModel relPhone = new PersistenceTableRelationModel("kneo.test.helloodata.CompositeKey::address", "PHONES", "FK_PHONE", "ID", "CONSTRAINT_8C9F7", "CONSTRAINT_INDEX_E67");
+        model = new PersistenceTableModel("kneo.test.helloodata.CompositeKey::address", Arrays.asList(column7, column8), Collections.singletonList(relPhone));
+        when(dbMetadataUtil.getTableMetadata("kneo.test.helloodata.CompositeKey::address")).thenReturn(model);
+
+        PersistenceTableColumnModel column3 = new PersistenceTableColumnModel("NUMBER", "Edm.Int32", true);
+        PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("FK_COMPANY_ID", "Edm.Int32", false);
+        PersistenceTableColumnModel column5 = new PersistenceTableColumnModel("FK_EMPLOYEE_NUMBER", "Edm.Int32", false);
+        PersistenceTableColumnModel column6 = new PersistenceTableColumnModel("FK_ADDRESS_ID", "Edm.Int32", false);
+        PersistenceTableRelationModel rel = new PersistenceTableRelationModel("kneo.test.helloodata.CompositeKey::phones", "kneo.test.helloodata.CompositeKey::employee", "FK_COMPANY_ID", "COMPANY_ID", "CONSTRAINT_8C", "CONSTRAINT_INDEX_4");
+        PersistenceTableRelationModel rel2 = new PersistenceTableRelationModel("kneo.test.helloodata.CompositeKey::phones", "kneo.test.helloodata.CompositeKey::employee", "FK_EMPLOYEE_NUMBER", "EMPLOYEE_NUMBER", "CONSTRAINT_8C9", "CONSTRAINT_INDEX_43");
+        PersistenceTableRelationModel rel3 = new PersistenceTableRelationModel("kneo.test.helloodata.CompositeKey::phones", "kneo.test.helloodata.CompositeKey::address", "FK_ADDRESS_ID", "ID", "CONSTRAINT_8C9F", "CONSTRAINT_INDEX_E6");
+        model = new PersistenceTableModel("kneo.test.helloodata.CompositeKey::phones", Arrays.asList(column3, column4, column5, column6), Arrays.asList(rel, rel2, rel3));
+        when(dbMetadataUtil.getTableMetadata("kneo.test.helloodata.CompositeKey::phones")).thenReturn(model);
+
+        ODataDefinition oDataDefinition = XSKODataUtils.convertXSKODataModelToODataDefinition(xskoDataModel, dbMetadataUtil);
+
+        assertEquals("1", oDataDefinition.getAssociations().get(0).getFrom().getMultiplicity());
+        assertEquals("*", oDataDefinition.getAssociations().get(0).getTo().getMultiplicity());
+    }
+
     @Test
     public void testConvertWithoutSetOfPropAndLimitedExposedNavigations() throws Exception {
         XSKODataParser parser = new XSKODataParser();

--- a/modules/engines/engine-xsodata/src/test/java/XSKODataUtilsTest.java
+++ b/modules/engines/engine-xsodata/src/test/java/XSKODataUtilsTest.java
@@ -11,6 +11,7 @@
  */
 
 import com.sap.xsk.parser.xsodata.model.XSKHDBXSODATAEventType;
+import com.sap.xsk.parser.xsodata.model.XSKHDBXSODATAHandlerMethod;
 import com.sap.xsk.xsodata.ds.model.XSKODataModel;
 import com.sap.xsk.xsodata.ds.service.XSKOData2TransformerException;
 import com.sap.xsk.xsodata.ds.service.XSKODataParser;
@@ -270,6 +271,9 @@ public class XSKODataUtilsTest {
         assertEquals(ODataHandlerMethods.create.name(),entity1.getHandlers().get(2).getMethod());
         assertEquals(ODataHandlerTypes.forbid.name(),entity1.getHandlers().get(2).getType());
         assertNull(entity1.getHandlers().get(2).getHandler());
+        assertEquals("false",entity1.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.CREATE.getOdataSAPAnnotation()));
+        assertNull(entity1.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.UPDATE.getOdataSAPAnnotation()));
+        assertNull(entity1.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.DELETE.getOdataSAPAnnotation()));
 
         ODataEntityDefinition entity2 = oDataDefinition.getEntities().get(1);
         assertEquals(4,entity2.getHandlers().size());
@@ -285,6 +289,9 @@ public class XSKODataUtilsTest {
         assertEquals(ODataHandlerMethods.delete.name(),entity2.getHandlers().get(3).getMethod());
         assertEquals(ODataHandlerTypes.on.name(),entity2.getHandlers().get(3).getType());
         assertEquals("sample.odata::deleteMethod",entity2.getHandlers().get(3).getHandler());
+        assertNull(entity2.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.CREATE.getOdataSAPAnnotation()));
+        assertNull(entity2.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.UPDATE.getOdataSAPAnnotation()));
+        assertNull(entity2.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.DELETE.getOdataSAPAnnotation()));
 
         ODataEntityDefinition entity3 = oDataDefinition.getEntities().get(2);
         assertEquals(2,entity3.getHandlers().size());
@@ -294,6 +301,9 @@ public class XSKODataUtilsTest {
         assertEquals(ODataHandlerMethods.delete.name(),entity3.getHandlers().get(1).getMethod());
         assertEquals(ODataHandlerTypes.forbid.name(),entity3.getHandlers().get(1).getType());
         assertNull(entity3.getHandlers().get(1).getHandler());
+        assertNull(entity3.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.CREATE.getOdataSAPAnnotation()));
+        assertNull(entity3.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.UPDATE.getOdataSAPAnnotation()));
+        assertEquals("false",entity3.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.DELETE.getOdataSAPAnnotation()));
 
         ODataEntityDefinition entity4 = oDataDefinition.getEntities().get(3);
         assertEquals(3,entity4.getHandlers().size());
@@ -306,6 +316,9 @@ public class XSKODataUtilsTest {
         assertEquals(ODataHandlerMethods.delete.name(),entity4.getHandlers().get(2).getMethod());
         assertEquals(ODataHandlerTypes.forbid.name(),entity4.getHandlers().get(2).getType());
         assertNull(entity4.getHandlers().get(2).getHandler());
+        assertEquals("false",entity4.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.CREATE.getOdataSAPAnnotation()));
+        assertEquals("false",entity4.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.UPDATE.getOdataSAPAnnotation()));
+        assertEquals("false",entity4.getAnnotationsEntitySet().get(XSKHDBXSODATAHandlerMethod.DELETE.getOdataSAPAnnotation()));
     }
 
     @Test(expected = XSKOData2TransformerException.class)

--- a/modules/engines/engine-xsodata/src/test/resources/entity_multiplicity_one_to_many.xsodata
+++ b/modules/engines/engine-xsodata/src/test/resources/entity_multiplicity_one_to_many.xsodata
@@ -1,0 +1,14 @@
+service namespace "np"{
+
+"kneo.test.helloodata.CompositeKey::employee" as "Employees" with ("COMPANY_ID", "EMPLOYEE_NUMBER", "ORDER_ID")
+	navigates ("Employees_Phones" as "HisPhones");
+
+"kneo.test.helloodata.CompositeKey::phones" as "Phones";
+
+association "Employees_Phones" with referential constraint
+	 principal "Employees"("COMPANY_ID", "EMPLOYEE_NUMBER") multiplicity "1"
+     dependent "Phones"("FK_COMPANY_ID", "FK_EMPLOYEE_NUMBER") multiplicity "1..*" ;
+}
+annotations     {
+	enable      OData4SAP;
+}

--- a/modules/engines/engine-xsodata/src/test/resources/entity_with_keys.xsodata
+++ b/modules/engines/engine-xsodata/src/test/resources/entity_with_keys.xsodata
@@ -1,0 +1,9 @@
+service namespace "my.demo.namespace" {
+
+//Key Specification
+    "sample.odata::view" as "MyView" key ("ID","Text");
+    "sample.odata::view" as "MyView" keys ("ID","Text");
+    "sample.odata::view" as "MyView" key generate local "GenID";
+    "test/AN_AGENCY.analyticView" as "Revenue" keys generate local "GENERATED_ID";
+}
+

--- a/modules/parsers/parser-xsodata/com.sap.xsk.parser.xsodata/src/main/java/com/sap/xsk/parser/xsodata/model/XSKHDBXSODATAHandlerMethod.java
+++ b/modules/parsers/parser-xsodata/com.sap.xsk.parser.xsodata/src/main/java/com/sap/xsk/parser/xsodata/model/XSKHDBXSODATAHandlerMethod.java
@@ -15,18 +15,25 @@ package com.sap.xsk.parser.xsodata.model;
  * The text should reflect the values from org.eclipse.dirigible.engine.odata2.definition.ODataHandlerMethods
  */
 public enum XSKHDBXSODATAHandlerMethod {
-    CREATE("create"),
-    UPDATE("update"),
-    DELETE("delete");
+    CREATE("create", "sap:creatable"),
+    UPDATE("update", "sap:updatable"),
+    DELETE("delete", "sap:deletable");
 
     private final String odataHandlerType;
 
-    XSKHDBXSODATAHandlerMethod(String odataHandlerType) {
+    private final String odataSAPAnnotation;
+
+    XSKHDBXSODATAHandlerMethod(String odataHandlerType, String odataSAPAnnotation) {
         this.odataHandlerType = odataHandlerType;
+        this.odataSAPAnnotation = odataSAPAnnotation;
     }
 
     public String getOdataHandlerType() {
         return odataHandlerType;
+    }
+
+    public String getOdataSAPAnnotation() {
+        return odataSAPAnnotation;
     }
 
     public String value() {

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
 		<xtextVersion>2.18.0</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<dirigible.version>5.11.1</dirigible.version>
+		<dirigible.version>5.11.2</dirigible.version>
 
 		<maven.resource.plugin.version>3.0.2</maven.resource.plugin.version>
 		<maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>

--- a/samples/hdb-xsodata/order.hdbtable
+++ b/samples/hdb-xsodata/order.hdbtable
@@ -3,6 +3,6 @@ table.tableType = COLUMNSTORE;
 table.columns = [
 	{name = "ID"; sqlType = INTEGER; nullable = false;},
 	{name = "ID2"; sqlType = INTEGER; nullable = false;},
-	{name = "CustomerID"; sqlType = INTEGER; nullable = true;}];
+	{name = "CustomerID"; sqlType = INTEGER; nullable = true;},
+	{name = "ProductID"; sqlType = INTEGER; nullable = true;}];
 table.primaryKey.pkcolumns = ["ID", "ID2"];
-

--- a/samples/hdb-xsodata/orderView.hdbview
+++ b/samples/hdb-xsodata/orderView.hdbview
@@ -1,4 +1,4 @@
 schema="HELLO_ODATA";
-query="SELECT * FROM \"toni::order\"";
-depends_on= ["toni::order"];
+query="SELECT * FROM \"hdb-xsodata::order\"";
+depends_on= ["hdb-xsodata::order"];
 

--- a/samples/hdb-xsodata/orderView.xsodata
+++ b/samples/hdb-xsodata/orderView.xsodata
@@ -1,0 +1,20 @@
+service namespace "np_xsodata"{
+ 
+	"hdb-xsodata::orderView"  as "MyView1" key ("ID","ID2")
+	 create forbidden
+	 update forbidden
+     delete forbidden;
+	"hdb-xsodata::orderView"  as "MyView2" without ("CustomerID") key ("ID","ID2"); 
+	
+	"hdb-xsodata::orderView"  as "MyView3"  key ("CustomerID"); 
+	"hdb-xsodata::orderView"  as "MyView4" with ("CustomerID", "ProductID") key ("CustomerID"); 
+	
+	"hdb-xsodata::orderView"  as "MyView5" key generate local "GenID"; 
+	
+	//keys can not be defined for table
+	"hdb-xsodata::order" as "MyTable";
+}
+annotations     {
+	enable      OData4SAP;
+	enable      OData4SAP;
+}


### PR DESCRIPTION
->implement [OData Service-Definition Features](https://help.sap.com/viewer/4505d0bdaf4948449b7f7379d24d0f0d/2.0.03/en-US/fda42888439142dc9984d3560bc68206.html) ->Key Specification
->refactor XSKOData2ODataXTransformer to use the dirigible logic
-> fix issue ->olingo do not support '1..*' from xsodata --> solution is to convert it to *
-> XSK supports only the below annotation cases:
| edm:EntitySet | Parameter Value | Requirement                                                                                                  |
| ------------- | --------------- | ------------------------------------------------------------------------------------------------------------ |
| sap:creatable | “false”         | The "create forbidden" setting is defined for the entity set in the OData service definition (.xsodata) file |
| sap:updatable | “false”         | The "update forbidden" setting is defined for the entity set in the OData service definition (.xsodata) file |
| sap:deletable | “false”         | The "delete forbidden" setting is defined for the entity set in the OData service definition (.xsodata) file |

->Implement tests