### PR TITLE
net.http API changes and unit test

### DIFF
--- a/modules/api/api-xsjs/src/main/resources/xsk/http/http.js
+++ b/modules/api/api-xsjs/src/main/resources/xsk/http/http.js
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2019-2020 SAP SE or an SAP affiliate company and XSK contributors
+ * Copyright (c) 2019-2021 SAP SE or an SAP affiliate company and XSK contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, v2.0
  * which accompanies this distribution, and is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-FileCopyrightText: 2019-2020 SAP SE or an SAP affiliate company and XSK contributors
+ * SPDX-FileCopyrightText: 2019-2021 SAP SE or an SAP affiliate company and XSK contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 var dClient = require("http/v4/client");
@@ -81,18 +81,18 @@ exports.readDestination = function(destinationPackage, destinationName) {
 
 	var destResourceLineArray = destResourceContent.split(";");
 
-	var destinationObject = {};
+  var destination = new exports.Destination();
 
 	destResourceLineArray.forEach(destResourceLine =>  {
 		var splitKeyValueArray = destResourceLine.split("=");
 
 		var processedDestValue = processDestValue(splitKeyValueArray[1]);
 		var destKey = splitKeyValueArray[0].trim();
-		destinationObject[destKey] = processedDestValue;
+    destination[destKey] = processedDestValue;
 
 	});
 
-	return destinationObject;
+	return destination;
 };
 
 exports.Client = function() {
@@ -113,7 +113,7 @@ exports.Client = function() {
 	};
 
 	this.close = function() {
-		// TODO No dirigible functionality
+		// Empty. Called automatically inside HttpClientFacade
 	};
 
 	this.getResponse = function() {
@@ -333,4 +333,8 @@ function parseDestValue(destValue) {
 	}
 
 	return destValue;
+}
+
+exports.Destination = function() {
+
 }

--- a/modules/engines/engine-xsjs/src/test/java/com/sap/xsk/engine/api/test/XSKApiSuiteTest.java
+++ b/modules/engines/engine-xsjs/src/test/java/com/sap/xsk/engine/api/test/XSKApiSuiteTest.java
@@ -71,6 +71,7 @@ public class XSKApiSuiteTest extends AbstractGuiceTest {
     TEST_MODULES.add("test/xsk/import/import.xsjs");
     TEST_MODULES.add("test/xsk/util/util.xsjs");
     TEST_MODULES.add("test/xsk/util/codec/codec.xsjs");
+    TEST_MODULES.add("test/xsk/http/http.xsjs");
   }
 
   /**

--- a/modules/engines/engine-xsjs/src/test/resources/test/xsk/http/http.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/test/xsk/http/http.xsjs
@@ -1,0 +1,15 @@
+let http = $.net.http;
+
+let client = new http.Client();
+let request = new http.Request(http.GET, "/");
+let destination = new http.Destination()
+
+destination.host="https://services.odata.org";
+destination.pathPrefix="/V4/Northwind/Northwind.svc/";
+
+client.setTimeout(10);
+
+client.request(request, destination);
+let response = client.getResponse();
+
+response.status === http.OK && response.cookies != null && response.headers != null && response.body != null


### PR DESCRIPTION
Resolves #20 

$.net.http API changes.

Changelog
New
Added Destination class to http API.
Added a unit test for the http API.

Documentation
https://github.com/SAP/xsk/wiki/api-net.http