### PR TITLE
HDBTIParser now uses the error logger in XSKCommonUtils

### DIFF
--- a/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/api/IXSKTableImportArtifactFactory.java
+++ b/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/api/IXSKTableImportArtifactFactory.java
@@ -11,6 +11,7 @@
  */
 package com.sap.xsk.hdbti.api;
 
+import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdbti.model.XSKTableImportArtifact;
 import com.sap.xsk.parser.hdbti.custom.IXSKHDBTIParser;
 import com.sap.xsk.parser.hdbti.exception.XSKHDBTISyntaxErrorException;
@@ -18,7 +19,7 @@ import java.io.IOException;
 import org.eclipse.dirigible.repository.api.IRepository;
 
 public interface IXSKTableImportArtifactFactory {
-    XSKTableImportArtifact parseTableImport(String content, String location) throws IOException, XSKHDBTISyntaxErrorException;
+    XSKTableImportArtifact parseTableImport(String content, String location) throws IOException, XSKHDBTISyntaxErrorException, XSKArtifactParserException;
 
     IRepository getRepository();
 

--- a/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/api/IXSKTableImportParser.java
+++ b/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/api/IXSKTableImportParser.java
@@ -11,10 +11,11 @@
  */
 package com.sap.xsk.hdbti.api;
 
+import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdbti.model.XSKTableImportArtifact;
 import com.sap.xsk.parser.hdbti.exception.XSKHDBTISyntaxErrorException;
 import java.io.IOException;
 
 public interface IXSKTableImportParser {
-    XSKTableImportArtifact parseTableImportArtifact(String location, String content) throws IOException, XSKHDBTISyntaxErrorException;
+    XSKTableImportArtifact parseTableImportArtifact(String location, String content) throws IOException, XSKHDBTISyntaxErrorException, XSKArtifactParserException;
 }

--- a/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/service/XSKTableImportParser.java
+++ b/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/service/XSKTableImportParser.java
@@ -13,6 +13,7 @@ package com.sap.xsk.hdbti.service;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdbti.api.IXSKTableImportParser;
 import com.sap.xsk.hdbti.model.XSKTableImportArtifact;
 import com.sap.xsk.hdbti.model.XSKTableImportConfigurationDefinition;
@@ -40,7 +41,8 @@ public class XSKTableImportParser implements IXSKTableImportParser {
     private IXSKTableImportArtifactFactory xskTableImportArtifactFactory;
 
     @Override
-    public XSKTableImportArtifact parseTableImportArtifact(String location, String content) throws IOException, XSKHDBTISyntaxErrorException {
+    public XSKTableImportArtifact parseTableImportArtifact(String location, String content)
+        throws IOException, XSKHDBTISyntaxErrorException, XSKArtifactParserException {
         XSKTableImportArtifact parsedArtifact = xskTableImportArtifactFactory.parseTableImport(content, location);
         parsedArtifact.setName(new File(location).getName());
         parsedArtifact.setLocation(location);

--- a/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/synchronizer/XSKTableImportSynchronizer.java
+++ b/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/synchronizer/XSKTableImportSynchronizer.java
@@ -15,6 +15,7 @@ import static java.text.MessageFormat.format;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModel;
 import com.sap.xsk.hdb.ds.synchronizer.XSKDataStructuresSynchronizer;
@@ -151,6 +152,8 @@ public class XSKTableImportSynchronizer extends AbstractSynchronizer {
         throw new SynchronizationException();
       } catch (XSKHDBTISyntaxErrorException syntaxErrorException) {
         logger.error(syntaxErrorException.getMessage(), syntaxErrorException);
+      } catch (XSKArtifactParserException parserException) {
+        logger.error(parserException.getMessage(), parserException);
       }
     } else if (resourceName.endsWith(IXSKTableImportModel.FILE_EXTENSION_CSV)) {
       List<XSKTableImportToCsvRelation> affectedHdbtiToCsvRelations = xskCsvToHdbtiRelationDao
@@ -173,6 +176,8 @@ public class XSKTableImportSynchronizer extends AbstractSynchronizer {
       logger.error("Error during the force reimport of an HDBTI file due to a linked csv file change", e);
     } catch (XSKHDBTISyntaxErrorException syntaxErrorException) {
       logger.error(syntaxErrorException.getMessage());
+    } catch (XSKArtifactParserException parserException) {
+      logger.error(parserException.getMessage(), parserException);
     }
 
   }

--- a/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/transformer/XSKTableImportArtifactFactory.java
+++ b/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/transformer/XSKTableImportArtifactFactory.java
@@ -13,6 +13,7 @@ package com.sap.xsk.hdbti.transformer;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdbti.api.IXSKHDBTICoreService;
 import com.sap.xsk.hdbti.api.IXSKTableImportArtifactFactory;
 import com.sap.xsk.hdbti.model.XSKTableImportArtifact;
@@ -52,7 +53,7 @@ public class XSKTableImportArtifactFactory implements IXSKTableImportArtifactFac
     private IXSKHDBTIParser xskHdbtiParser;
 
     @Override
-    public XSKTableImportArtifact parseTableImport(String content, String location) throws IOException, XSKHDBTISyntaxErrorException {
+    public XSKTableImportArtifact parseTableImport(String content, String location) throws IOException, XSKHDBTISyntaxErrorException, XSKArtifactParserException {
         XSKTableImportArtifact tableImportArtifact = new XSKTableImportArtifact();
         List<XSKTableImportConfigurationDefinition> importConfigurationDefinitions = new ArrayList<>();
         List<XSKTableImportToCsvRelation> tableImportToCsvRelations = new ArrayList<>();
@@ -60,7 +61,7 @@ public class XSKTableImportArtifactFactory implements IXSKTableImportArtifactFac
         tableImportArtifact.setImportConfigurationDefinition(importConfigurationDefinitions);
         tableImportArtifact.setTableImportToCsvRelations(tableImportToCsvRelations);
 
-        XSKHDBTIImportModel importObject = xskHdbtiParser.parse(content);
+        XSKHDBTIImportModel importObject = xskHdbtiParser.parse(location, content);
 
         for (XSKHDBTIImportConfigModel configuration : importObject.getConfigModels()) {
             addHdbtiToCsvRelation(tableImportArtifact, configuration, location);

--- a/modules/parsers/parser-hdbti/pom.xml
+++ b/modules/parsers/parser-hdbti/pom.xml
@@ -38,6 +38,11 @@
             <version>${commons.io}</version>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>com.sap.xsk</groupId>
+        <artifactId>xsk-modules-engines-commons</artifactId>
+        <version>0.7.0-SNAPSHOT</version>
+      </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/modules/parsers/parser-hdbti/src/main/java/com/sap/xsk/parser/hdbti/custom/IXSKHDBTIParser.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/sap/xsk/parser/hdbti/custom/IXSKHDBTIParser.java
@@ -11,11 +11,12 @@
  */
 package com.sap.xsk.parser.hdbti.custom;
 
+import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.parser.hdbti.exception.XSKHDBTISyntaxErrorException;
 import com.sap.xsk.parser.hdbti.models.XSKHDBTIImportModel;
 
 import java.io.IOException;
 
 public interface IXSKHDBTIParser {
-    XSKHDBTIImportModel parse(String content) throws IOException, XSKHDBTISyntaxErrorException;
+    XSKHDBTIImportModel parse(String location, String content) throws IOException, XSKHDBTISyntaxErrorException, XSKArtifactParserException;
 }

--- a/modules/parsers/parser-hdbti/src/main/java/com/sap/xsk/parser/hdbti/custom/XSKHDBTISyntaxErrorListener.java
+++ b/modules/parsers/parser-hdbti/src/main/java/com/sap/xsk/parser/hdbti/custom/XSKHDBTISyntaxErrorListener.java
@@ -14,19 +14,20 @@ package com.sap.xsk.parser.hdbti.custom;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
+import java.util.ArrayList;
 
 public class XSKHDBTISyntaxErrorListener extends BaseErrorListener {
 
-  private String errorMessage;
+  private final ArrayList<String> errorMessages = new ArrayList<>();
 
   @Override
   public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg,
       RecognitionException e) {
-    this.errorMessage = "line " + line + ":" + charPositionInLine + " at " +
-        offendingSymbol + ": " + msg;
+    this.errorMessages.add("line " + line + ":" + charPositionInLine + " at " +
+        offendingSymbol + ": " + msg);
   }
 
-  public String getErrorMessage() {
-    return errorMessage;
+  public ArrayList<String> getErrorMessages() {
+    return errorMessages;
   }
 }

--- a/modules/parsers/parser-hdbti/src/test/java/com/sap/xsk/parser/hdbti/custom/XSKHDBTIParserTest.java
+++ b/modules/parsers/parser-hdbti/src/test/java/com/sap/xsk/parser/hdbti/custom/XSKHDBTIParserTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.parser.hdbti.exception.DuplicateFieldNameException;
 import com.sap.xsk.parser.hdbti.exception.XSKHDBTISyntaxErrorException;
 import com.sap.xsk.parser.hdbti.models.XSKHDBTIImportConfigModel;
@@ -27,12 +28,13 @@ import org.junit.Test;
 public class XSKHDBTIParserTest {
 
   @Test
-  public void testValidInputAllFieldsAssignedProperlyParseSuccessfully() throws IOException, XSKHDBTISyntaxErrorException {
+  public void testValidInputAllFieldsAssignedProperlyParseSuccessfully()
+      throws IOException, XSKHDBTISyntaxErrorException, XSKArtifactParserException {
     String hdbtiSample = org.apache.commons.io.IOUtils
         .toString(XSKHDBTIParserTest.class.getResourceAsStream("/sample.hdbti"), StandardCharsets.UTF_8);
 
     XSKHDBTIParser xskhdbtiParser = new XSKHDBTIParser();
-    XSKHDBTIImportModel importModel = xskhdbtiParser.parse(hdbtiSample);
+    XSKHDBTIImportModel importModel = xskhdbtiParser.parse("/test/xsk/com/sap/sample.hdbti", hdbtiSample);
     XSKHDBTIImportConfigModel configModel = importModel.getConfigModels().get(0);
 
     int expectedConfigsSize = 1;
@@ -63,8 +65,8 @@ public class XSKHDBTIParserTest {
     XSKHDBTIParser xskhdbtiParser = new XSKHDBTIParser();
 
     try {
-      xskhdbtiParser.parse(hdbtiSample);
-    } catch (XSKHDBTISyntaxErrorException syntaxErrorException) {
+      xskhdbtiParser.parse("/test/xsk/com/sap/invalidSyntax.hdbti", hdbtiSample);
+    } catch (XSKArtifactParserException parseErrorException) {
       assertTrue(true);
     } catch (Exception e) {
       fail();
@@ -78,7 +80,7 @@ public class XSKHDBTIParserTest {
     XSKHDBTIParser xskhdbtiParser = new XSKHDBTIParser();
 
     try {
-      xskhdbtiParser.parse(hdbtiSample);
+      xskhdbtiParser.parse("/test/xsk/com/sap/duplicateKeys.hdbti", hdbtiSample);
     } catch (DuplicateFieldNameException duplicateFieldNameException) {
       assertTrue(true);
     } catch (Exception e) {
@@ -87,11 +89,28 @@ public class XSKHDBTIParserTest {
   }
 
   @Test
-  public void testParseConfigObjectFieldsRandomOrderShouldPass() throws IOException, XSKHDBTISyntaxErrorException {
+  public void testParseConfigObjectFieldsRandomOrderShouldPass()
+      throws IOException, XSKHDBTISyntaxErrorException, XSKArtifactParserException {
     String hdbtiSample = org.apache.commons.io.IOUtils
         .toString(XSKHDBTIParserTest.class.getResourceAsStream("/randomOrder.hdbti"), StandardCharsets.UTF_8);
     XSKHDBTIParser xskhdbtiParser = new XSKHDBTIParser();
 
-    xskhdbtiParser.parse(hdbtiSample);
+    xskhdbtiParser.parse("/test/xsk/com/sap/randomOrder.hdbti", hdbtiSample);
+  }
+
+  @Test(expected = XSKArtifactParserException.class)
+  public void parseHDBTIContentWithLexerErrorFail() throws Exception {
+    String content = org.apache.commons.io.IOUtils
+        .toString(XSKHDBTIParserTest.class.getResourceAsStream("/lexerError.hdbti"), StandardCharsets.UTF_8);
+    XSKHDBTIParser xskhdbtiParser = new XSKHDBTIParser();
+    xskhdbtiParser.parse("/test/xsk/com/sap/lexerError.hdbti", content);
+  }
+
+  @Test(expected = XSKArtifactParserException.class)
+  public void parseHDBTIContentWithSyntaxErrorFail() throws Exception {
+    String content = org.apache.commons.io.IOUtils
+        .toString(XSKHDBTIParserTest.class.getResourceAsStream("/parserError.hdbti"), StandardCharsets.UTF_8);
+    XSKHDBTIParser xskhdbtiParser = new XSKHDBTIParser();
+    xskhdbtiParser.parse("/test/xsk/com/sap/syntaxError.hdbti", content);
   }
 }

--- a/modules/parsers/parser-hdbti/src/test/resources/lexerError.hdbti
+++ b/modules/parsers/parser-hdbti/src/test/resources/lexerError.hdbti
@@ -1,0 +1,5 @@
+import = [
+  {
+    tableerror = "myTable";
+  }
+];

--- a/modules/parsers/parser-hdbti/src/test/resources/parserError.hdbti
+++ b/modules/parsers/parser-hdbti/src/test/resources/parserError.hdbti
@@ -1,0 +1,5 @@
+import = [
+  {
+    table = "myTable"};
+  }
+];


### PR DESCRIPTION
Related to https://github.com/SAP/xsk/issues/321

Changelog
Lexer and parser errors will now be logged within XSKCommonUtils and an XSKArtifactParserException will be thrown.

Reason
This change makes it easier to fill a table/view with Parser errors.