### PR TITLE
Refactored the $.net unit test

### DIFF
--- a/modules/engines/engine-xsjs/src/test/java/com/sap/xsk/engine/api/test/XSKApiSuiteTest.java
+++ b/modules/engines/engine-xsjs/src/test/java/com/sap/xsk/engine/api/test/XSKApiSuiteTest.java
@@ -86,7 +86,6 @@ public class XSKApiSuiteTest extends AbstractDirigibleTest {
     TEST_MODULES.add("test/xsk/util/util.xsjs");
     TEST_MODULES.add("test/xsk/util/codec/codec.xsjs");
     TEST_MODULES.add("test/xsk/http/http.xsjs");
-    // TODO rework net.xsjs's test after upgrading mockito's versions in dirigible and xsk
     TEST_MODULES.add("test/xsk/net/net.xsjs");
 
     // HDB tests

--- a/modules/engines/engine-xsjs/src/test/resources/test/xsk/net/net.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/test/xsk/net/net.xsjs
@@ -1,6 +1,6 @@
-var net = $.net;
+let net = $.net;
 
-var mail = new net.Mail({
+let mail = new net.Mail({
    sender: {address: "sender@sap.com"},
    to: [{ name: "John Doe", address: "john.doe@sap.com", nameEncoding: "US-ASCII"}, {name: "Jane Doe", address: "jane.doe@sap.com"}],
    cc: ["cc1@sap.com", {address: "cc2@sap.com"}],
@@ -15,10 +15,10 @@ var mail = new net.Mail({
    })]
 });
 
-var smtp = new net.SMTPConnection();
+let smtp = new net.SMTPConnection();
 
-to = mail.to.map(e => e.address)
-cc = mail.cc.map(e => e.address)
-bcc = mail.bcc.map(e => e.address)
+let to = mail.to.map(e => e.address)
+let cc = mail.cc.map(e => e.address)
+let bcc = mail.bcc.map(e => e.address)
 
 to !== "" && to !== undefined && cc !== "" && cc !== undefined && bcc !== "" && bcc !== undefined && smtp.isClosed()

--- a/modules/engines/engine-xsjs/src/test/resources/test/xsk/net/net.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/test/xsk/net/net.xsjs
@@ -16,10 +16,9 @@ var mail = new net.Mail({
 });
 
 var smtp = new net.SMTPConnection();
-// TODO upgrade mockito's versions in dirigible and xsk to mock the static methods
-//smtp.send(mail);
-//var returnValue = mail.send();
 
 to = mail.to.map(e => e.address)
+cc = mail.cc.map(e => e.address)
+bcc = mail.bcc.map(e => e.address)
 
-to !== "" && to !== undefined && smtp.isClosed()
+to !== "" && to !== undefined && cc !== "" && cc !== undefined && bcc !== "" && bcc !== undefined && smtp.isClosed()


### PR DESCRIPTION
Resolves #268 

Changelog
Minor $.net unit test refactoring

The send() method requires additional SMPT host configuration which should be inside an integration test. Therefore, the current implementation of the unit test is sufficient.