### PR TITLE
[Migration Tools] Tests for migration tools backend 

### DIFF
--- a/modules/ide/ide-migration/pom.xml
+++ b/modules/ide/ide-migration/pom.xml
@@ -1,8 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-core</artifactId>
+      <version>3.4.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.dirigible</groupId>
+      <artifactId>dirigible-api</artifactId>
+      <version>${dirigible.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.dirigible</groupId>
+      <artifactId>dirigible-commons-api</artifactId>
+      <version>${dirigible.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.dirigible</groupId>
+      <artifactId>dirigible-commons-test</artifactId>
+      <version>${dirigible.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.dirigible</groupId>
+      <artifactId>dirigible-engine-javascript-graalvm</artifactId>
+      <version>${dirigible.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sap.xsk</groupId>
+      <artifactId>xsk-modules-engines-xsjs</artifactId>
+      <version>0.8.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.websocket</groupId>
+      <artifactId>javax.websocket-api</artifactId>
+      <version>1.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.websocket</groupId>
+      <artifactId>javax.websocket-api</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.websocket</groupId>
+      <artifactId>javax.websocket-api</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sap.cloud.db.jdbc</groupId>
+      <artifactId>ngdbc</artifactId>
+      <version>2.8.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.dirigible</groupId>
+      <artifactId>dirigible-repository-local</artifactId>
+      <version>${dirigible.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-	<parent>
+  <parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-modules-ide-parent</artifactId>
 		<version>0.8.0-SNAPSHOT</version>
@@ -14,12 +96,76 @@
 	<version>0.8.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
-	<properties>
-		<profile.content.phase>generate-sources</profile.content.phase>
-		<content.repository.name>xsk-ide-migration</content.repository.name>
-		<content.project.name>ide-migration</content.project.name>
+	<scm>
+		<url>${content.scm.url}</url>
+		<connection>${content.scm.connection}</connection>
+		<developerConnection>${content.scm.developerConnection}</developerConnection>
+	</scm>
 
-		<license.header.location>../../../licensing-header.txt</license.header.location>
-	</properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.sap.cloud</groupId>
+                  <artifactId>neo-java-web-sdk</artifactId>
+                  <version>4.2.4</version>
+                  <type>zip</type>
+                  <outputDirectory>tools/neo/neo-sdk/</outputDirectory>
+                  <overWrite>true</overWrite>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+
+          <execution>
+            <id>copy-migration-tools</id>
+            <phase>install</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>target/migration-tools</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>tools</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+
+    <profile.content.phase>generate-sources</profile.content.phase>
+    <content.repository.name>xsk-ide-migration</content.repository.name>
+    <content.project.name>ide-migration</content.project.name>
+    <content.repository.branch>main</content.repository.branch>
+    <content.source.directory>target/${content.project.name}</content.source.directory>
+    <content.output.directory>${basedir}/src/test/resources/META-INF/dirigible/${content.repository.name}/${content.project.name}</content.output.directory>
+
+    <license.header.location>../../../licensing-header.txt</license.header.location>
+    <skipTests>true</skipTests>
+  </properties>
 
 </project>

--- a/modules/ide/ide-migration/src/test/java/com/sap/xsk/ide/migration/AssertHolder.java
+++ b/modules/ide/ide-migration/src/test/java/com/sap/xsk/ide/migration/AssertHolder.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and XSK contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and XSK contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.xsk.ide.migration;
+
+import static org.junit.Assert.assertTrue;
+
+import org.graalvm.polyglot.HostAccess;
+
+public class AssertHolder {
+  @HostAccess.Export
+  public void callAssertTrue(Boolean res) {
+      assertTrue(res);
+  }
+}

--- a/modules/ide/ide-migration/src/test/java/com/sap/xsk/ide/migration/XSKMigrationJSServiceTest.java
+++ b/modules/ide/ide-migration/src/test/java/com/sap/xsk/ide/migration/XSKMigrationJSServiceTest.java
@@ -1,0 +1,110 @@
+package com.sap.xsk.ide.migration;
+
+/*
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and XSK contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and XSK contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Map;
+import org.apache.cxf.helpers.IOUtils;
+import org.eclipse.dirigible.commons.api.context.ContextException;
+import org.eclipse.dirigible.commons.api.scripting.ScriptingException;
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.commons.config.StaticObjects;
+import org.eclipse.dirigible.core.extensions.api.ExtensionsException;
+import org.eclipse.dirigible.core.test.AbstractDirigibleTest;
+import org.eclipse.dirigible.engine.js.graalvm.processor.GraalVMJavascriptEngineExecutor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.repository.api.RepositoryWriteException;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+
+public class XSKMigrationJSServiceTest extends AbstractDirigibleTest {
+
+  private IRepository repository;
+
+  private GraalVMJavascriptEngineExecutor graaljsJavascriptEngineExecutor;
+
+  @Before
+  public void setUp() throws Exception {
+    this.repository = (IRepository) StaticObjects.get(StaticObjects.REPOSITORY);
+    this.graaljsJavascriptEngineExecutor = new GraalVMJavascriptEngineExecutor();
+  }
+
+  @Test
+  public void runMigrationTest()
+      throws RepositoryWriteException, IOException, ScriptingException, ContextException, ExtensionsException, URISyntaxException {
+
+    String neoPath = getAbsolutePath("META-INF/dirigible/xsk-ide-migration/ide-migration/server/migration/neo.sh");
+    String targetPath = System.getProperty("user.dir") + "/target/";
+    String neoClientPath = targetPath + "migration-tools/neo/neo-sdk/tools/neo.sh";
+
+    assertNotNull(Configuration.get("ACCOUNT"));
+    assertNotNull(Configuration.get("HOST"));
+    assertNotNull(Configuration.get("USER"));
+    assertNotNull(Configuration.get("PASSWORD"));
+    assertNotNull(Configuration.get("DB"));
+    assertNotNull(Configuration.get("CUSER"));
+    assertNotNull(Configuration.get("HANA_PASSWORD"));
+
+    Map context = Map.ofEntries(
+        Map.entry("__async_callback", new AssertHolder()),
+        Map.entry("__neo_path", neoPath),
+        Map.entry("__neo_client_path", neoClientPath),
+        Map.entry("__account", Configuration.get("ACCOUNT")),
+        Map.entry("__host", Configuration.get("HOST")),
+        Map.entry("__user", Configuration.get("USER")),
+        Map.entry("__password", Configuration.get("PASSWORD")),
+        Map.entry("__db", Configuration.get("DB")),
+        Map.entry("__cuser", Configuration.get("CUSER")),
+        Map.entry("__hana_pass", Configuration.get("HANA_PASSWORD"))
+    );
+
+    runTest(this.graaljsJavascriptEngineExecutor, repository, "META-INF/dirigible/xsk-ide-migration/ide-migration/server/test/migrate.js", context);
+  }
+
+  private Object runTest(GraalVMJavascriptEngineExecutor executor, IRepository repository, String testModule, Map<Object, Object> context)
+      throws IOException, ScriptingException {
+
+    try (InputStream in = XSKMigrationJSServiceTest.class.getResourceAsStream(IRepositoryStructure.SEPARATOR + testModule)) {
+      if (in == null) {
+        throw new IOException(IRepositoryStructure.SEPARATOR + testModule + " does not exist");
+      }
+      repository.createResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + testModule,
+          IOUtils.readBytesFromStream(in));
+
+    } catch (RepositoryWriteException e) {
+      throw new IOException(IRepositoryStructure.SEPARATOR + testModule, e);
+    }
+
+    long start = System.currentTimeMillis();
+
+    Object result = executor.executeServiceModule(testModule, context);
+    long time = System.currentTimeMillis() - start;
+    System.out.printf("Migration test [%s] on engine [%s] passed for: %d ms%n", testModule, executor.getType(), time);
+    return result;
+  }
+
+  private String getAbsolutePath(String resourcePath) throws URISyntaxException, IOException {
+
+    URL res = getClass().getClassLoader().getResource(resourcePath);
+    File file = Paths.get(res.toURI()).toFile();
+    String absolutePath = file.getAbsolutePath();
+    return absolutePath;
+  }
+}


### PR DESCRIPTION
Implements #380

As part of the xsk-ide-migration project, migration tools backend is cloned into ide-migration module's resources. XSKMigrationJSServiceTest is created to run the e2e migration test in migrate.js.