### PR TITLE
Stopped the sync for xsaccess

### DIFF
--- a/modules/engines/engine-xssecurity/src/main/java/com/sap/xsk/xsaccess/ds/synchronizer/XSKSecuritySynchronizer.java
+++ b/modules/engines/engine-xssecurity/src/main/java/com/sap/xsk/xsaccess/ds/synchronizer/XSKSecuritySynchronizer.java
@@ -11,8 +11,6 @@
  */
 package com.sap.xsk.xsaccess.ds.synchronizer;
 
-import static java.text.MessageFormat.format;
-
 import com.sap.xsk.xsaccess.ds.api.IXSKAccessCoreService;
 import com.sap.xsk.xsaccess.ds.api.IXSKPrivilegeCoreService;
 import com.sap.xsk.xsaccess.ds.api.XSKAccessException;
@@ -36,7 +34,6 @@ import java.util.Set;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.dirigible.core.scheduler.api.AbstractSynchronizer;
-import org.eclipse.dirigible.core.scheduler.api.SchedulerException;
 import org.eclipse.dirigible.core.scheduler.api.SynchronizationException;
 import org.eclipse.dirigible.core.security.synchronizer.SecuritySynchronizer;
 import org.eclipse.dirigible.repository.api.IResource;
@@ -80,36 +77,36 @@ public class XSKSecuritySynchronizer extends AbstractSynchronizer {
    */
   @Override
   public void synchronize() {
-    synchronized (SecuritySynchronizer.class) {
-      if (beforeSynchronizing()) {
-        logger.trace("Synchronizing Privileges and Access artifacts...");
-        try {
-          startSynchronization(SYNCHRONIZER_NAME);
-          clearCache();
-          synchronizePredelivered();
-          synchronizeRegistry();
-          int immutablePrivilegesCount = PRIVILEGES_PREDELIVERED.size();
-          int immutableAccessCount = ACCESS_PREDELIVERED.size();
-
-          int mutablePrivilegesCount = PRIVILEGES_SYNCHRONIZED.size();
-          int mutableAccessCount = ACCESS_SYNCHRONIZED.size();
-          cleanup();
-          clearCache();
-          successfulSynchronization(SYNCHRONIZER_NAME,
-              format("Immutable: [Privileges: {0}, Access: {1}], Mutable: [Privileges: {2}, Access: {3}]",
-                  immutablePrivilegesCount, immutableAccessCount, mutablePrivilegesCount, mutableAccessCount));
-        } catch (Exception e) {
-          logger.error("Synchronizing process for Privileges and Access artifacts failed.", e);
-          try {
-            failedSynchronization(SYNCHRONIZER_NAME, e.getMessage());
-          } catch (SchedulerException e1) {
-            logger.error("Synchronizing process for Privileges and Access artifacts failed in registering the state log.", e);
-          }
-        }
-        logger.trace("Done synchronizing Privileges and Access artifacts.");
-        afterSynchronizing();
-      }
-    }
+//    synchronized (SecuritySynchronizer.class) {
+//      if (beforeSynchronizing()) {
+//        logger.trace("Synchronizing Privileges and Access artifacts...");
+//        try {
+//          startSynchronization(SYNCHRONIZER_NAME);
+//          clearCache();
+//          synchronizePredelivered();
+//          synchronizeRegistry();
+//          int immutablePrivilegesCount = PRIVILEGES_PREDELIVERED.size();
+//          int immutableAccessCount = ACCESS_PREDELIVERED.size();
+//
+//          int mutablePrivilegesCount = PRIVILEGES_SYNCHRONIZED.size();
+//          int mutableAccessCount = ACCESS_SYNCHRONIZED.size();
+//          cleanup();
+//          clearCache();
+//          successfulSynchronization(SYNCHRONIZER_NAME,
+//              format("Immutable: [Privileges: {0}, Access: {1}], Mutable: [Privileges: {2}, Access: {3}]",
+//                  immutablePrivilegesCount, immutableAccessCount, mutablePrivilegesCount, mutableAccessCount));
+//        } catch (Exception e) {
+//          logger.error("Synchronizing process for Privileges and Access artifacts failed.", e);
+//          try {
+//            failedSynchronization(SYNCHRONIZER_NAME, e.getMessage());
+//          } catch (SchedulerException e1) {
+//            logger.error("Synchronizing process for Privileges and Access artifacts failed in registering the state log.", e);
+//          }
+//        }
+//        logger.trace("Done synchronizing Privileges and Access artifacts.");
+//        afterSynchronizing();
+//      }
+//    }
   }
 
   /**


### PR DESCRIPTION
Resolves #441 

Stopped the sync of `.xsaccess` artifact due to parse error. The error is related to the parsing of the `authentication` key as specified in the issue when parsing a json like this:
```
{
  "exposed":true,
  "authentication":[{"method":"LogonTicket"},{"method":"Basic"}]
}
```
The value can be an array of multiple authentication methods but the parser is expecting only one.