### PR TITLE
Replaced printStackTrace() with logger

### DIFF
--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbdd/XSKHdbddParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbdd/XSKHdbddParser.java
@@ -33,12 +33,20 @@ import com.sap.xsk.parser.hdbdd.symbols.type.custom.StructuredDataTypeSymbol;
 import com.sap.xsk.parser.utils.ParserConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.utils.XSKConstants;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.io.IOUtils;
 import org.eclipse.dirigible.api.v3.security.UserFacade;
 import org.eclipse.dirigible.commons.config.StaticObjects;
 import org.eclipse.dirigible.core.problems.exceptions.ProblemsException;
@@ -46,13 +54,6 @@ import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.sql.Timestamp;
-import java.util.*;
 
 public class XSKHdbddParser implements XSKDataStructureParser {
 
@@ -124,7 +125,7 @@ public class XSKHdbddParser implements XSKDataStructureParser {
         IResource loadedResource = this.repository.getResource("/registry/public/" + fileLocation);
         parseHdbdd(fileLocation, new String(loadedResource.getContent()));
       } catch (IOException | ProblemsException | XSKArtifactParserException e) {
-        e.printStackTrace();
+        logger.error(e.getMessage(), e);
       }
     });
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymCreateProcessor.java
@@ -65,7 +65,7 @@ public class HDBSynonymCreateProcessor extends AbstractXSKProcessor<XSKDataStruc
           logger.warn(format("Synonym [{0}] already exists during the create process", value.getSynonymSchema() + "." + key));
         }
       } catch (SQLException | ProblemsException exception) {
-        exception.printStackTrace();
+        logger.error(exception.getMessage(), exception);
       }
     });
   }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymDropProcessor.java
@@ -60,7 +60,7 @@ public class HDBSynonymDropProcessor extends AbstractXSKProcessor<XSKDataStructu
                     logger.warn(format("Synonym [{0}] does not exists during the drop process", value.getSynonymSchema() + "." + key));
                 }
             } catch (SQLException | ProblemsException exception) {
-                exception.printStackTrace();
+                logger.error(exception.getMessage(), exception);
             }
         });
     }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/synchronizer/XSKDataStructuresSynchronizer.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/synchronizer/XSKDataStructuresSynchronizer.java
@@ -392,7 +392,7 @@ public class XSKDataStructuresSynchronizer extends AbstractSynchronizer {
     try {
       xskHDBCoreFacade.handleResourceSynchronization(resource);
     } catch (XSKDataStructuresException e) {
-      e.printStackTrace();
+      logger.error(e.getMessage(), e);
     }
   }
 
@@ -406,7 +406,7 @@ public class XSKDataStructuresSynchronizer extends AbstractSynchronizer {
     try {
       this.xskHDBCoreFacade.cleanup();
     } catch (XSKDataStructuresException e) {
-      e.printStackTrace();
+      logger.error(e.getMessage(), e);
     }
   }
 }

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/repository/TestRepository.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/repository/TestRepository.java
@@ -14,9 +14,14 @@ package com.sap.xsk.hdb.ds.test.repository;
 import java.io.IOException;
 import org.eclipse.dirigible.repository.api.IResource;
 import org.eclipse.dirigible.repository.api.RepositoryReadException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestRepository extends AbstractTestRepository {
-    @Override
+
+  private static final Logger logger = LoggerFactory.getLogger(TestRepository.class);
+
+  @Override
     public IResource getResource(String s) {
         try {
             byte[] content = TestRepository.class.getResourceAsStream(s).readAllBytes();
@@ -24,7 +29,7 @@ public class TestRepository extends AbstractTestRepository {
             resource.setContent(content);
             return resource;
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
         }
 
         return null;

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/service/XSKDataStructureTopologySorterTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/service/XSKDataStructureTopologySorterTest.java
@@ -11,30 +11,31 @@
  */
 package com.sap.xsk.hdb.ds.test.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.sap.xsk.hdb.ds.model.XSKDataStructureDependencyModel;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModel;
-import com.sap.xsk.hdb.ds.model.XSKDataStructureModelException;
 import com.sap.xsk.hdb.ds.service.XSKDataStructureTopologicalSorter;
-import org.eclipse.dirigible.database.ds.model.DataStructureDependencyModel;
-import org.eclipse.dirigible.database.ds.model.DataStructureModel;
-import org.eclipse.dirigible.database.ds.model.DataStructureModelException;
-import org.eclipse.dirigible.database.ds.model.DataStructureTopologicalSorter;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import static org.junit.Assert.*;
+import org.eclipse.dirigible.database.ds.model.DataStructureModelException;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Class DataStructureTopologySorter.
  */
 public class XSKDataStructureTopologySorterTest {
 
-	/**
+  private static final Logger logger = LoggerFactory.getLogger(XSKDataStructureTopologySorterTest.class);
+
+  /**
 	 * Test sort.
 	 */
 	@Test
@@ -78,7 +79,7 @@ public class XSKDataStructureTopologySorterTest {
 		try {
 			XSKDataStructureTopologicalSorter.sort(models, output, external);
 		} catch (DataStructureModelException e) {
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			fail(e.getMessage());
 		}
 

--- a/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/service/XSKHDBTICoreService.java
+++ b/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/service/XSKHDBTICoreService.java
@@ -11,8 +11,16 @@
  */
 package com.sap.xsk.hdbti.service;
 
+import static java.lang.String.format;
+
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
-import com.sap.xsk.hdbti.api.*;
+import com.sap.xsk.hdbti.api.IXSKCSVRecordDao;
+import com.sap.xsk.hdbti.api.IXSKCsvToHdbtiRelationDao;
+import com.sap.xsk.hdbti.api.IXSKHDBTICoreService;
+import com.sap.xsk.hdbti.api.IXSKImportedCSVRecordDao;
+import com.sap.xsk.hdbti.api.IXSKTableImportArtifactDao;
+import com.sap.xsk.hdbti.api.IXSKTableImportModel;
+import com.sap.xsk.hdbti.api.XSKTableImportException;
 import com.sap.xsk.hdbti.dao.XSKCSVRecordDao;
 import com.sap.xsk.hdbti.dao.XSKCsvToHdbtiRelationDao;
 import com.sap.xsk.hdbti.dao.XSKImportedCSVRecordDao;
@@ -23,6 +31,12 @@ import com.sap.xsk.hdbti.model.XSKTableImportConfigurationDefinition;
 import com.sap.xsk.hdbti.utils.XSKCsvRecordMetadata;
 import com.sap.xsk.utils.XSKCommonsDBUtils;
 import com.sap.xsk.utils.XSKUtils;
+import java.sql.SQLException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.cxf.common.util.StringUtils;
@@ -36,194 +50,190 @@ import org.eclipse.dirigible.repository.api.IRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.sql.DataSource;
-import java.sql.SQLException;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static java.lang.String.format;
-
 public class XSKHDBTICoreService implements IXSKHDBTICoreService {
 
-    private static final Logger logger = LoggerFactory.getLogger(XSKHDBTICoreService.class);
+  private static final Logger logger = LoggerFactory.getLogger(XSKHDBTICoreService.class);
 
-    private IXSKCSVRecordDao xskcsvRecordDao = new XSKCSVRecordDao();
-    private IXSKImportedCSVRecordDao xskImportedCSVRecordDao = new XSKImportedCSVRecordDao();
-    private IXSKTableImportArtifactDao xskTableImportArtifactDao = new XSKTableImportArtifactDao();
-    private IXSKCsvToHdbtiRelationDao xskCsvToHdbtiRelationDao = new XSKCsvToHdbtiRelationDao();
-    private IRepository repository = (IRepository) StaticObjects.get(StaticObjects.REPOSITORY);
-    private DBMetadataUtil dbMetadataUtil = new DBMetadataUtil();
-    private DataSource dataSource = (DataSource) StaticObjects.get(StaticObjects.DATASOURCE);
+  private IXSKCSVRecordDao xskcsvRecordDao = new XSKCSVRecordDao();
+  private IXSKImportedCSVRecordDao xskImportedCSVRecordDao = new XSKImportedCSVRecordDao();
+  private IXSKTableImportArtifactDao xskTableImportArtifactDao = new XSKTableImportArtifactDao();
+  private IXSKCsvToHdbtiRelationDao xskCsvToHdbtiRelationDao = new XSKCsvToHdbtiRelationDao();
+  private IRepository repository = (IRepository) StaticObjects.get(StaticObjects.REPOSITORY);
+  private DBMetadataUtil dbMetadataUtil = new DBMetadataUtil();
+  private DataSource dataSource = (DataSource) StaticObjects.get(StaticObjects.DATASOURCE);
 
-    @Override
-    public void insertCsvRecords(List<CSVRecord> recordsToInsert, List<String> headerNames,
-                                 XSKTableImportConfigurationDefinition tableImportConfigurationDefinition)
-            throws SQLException {
-        String tableName = convertToActualTableName(tableImportConfigurationDefinition.getTable());
-        PersistenceTableModel tableModel = dbMetadataUtil.getTableMetadata(tableName, tableImportConfigurationDefinition.getSchema());
-        for (CSVRecord csvRecord : recordsToInsert) {
-            try {
-                XSKCsvRecordMetadata csvRecordMetadata = new XSKCsvRecordMetadata(csvRecord, tableModel, headerNames,
-                        tableImportConfigurationDefinition.getDistinguishEmptyFromNull());
-                xskcsvRecordDao.save(csvRecordMetadata);
+  @Override
+  public void insertCsvRecords(List<CSVRecord> recordsToInsert, List<String> headerNames,
+      XSKTableImportConfigurationDefinition tableImportConfigurationDefinition)
+      throws SQLException {
+    String tableName = convertToActualTableName(tableImportConfigurationDefinition.getTable());
+    PersistenceTableModel tableModel = dbMetadataUtil.getTableMetadata(tableName, tableImportConfigurationDefinition.getSchema());
+    for (CSVRecord csvRecord : recordsToInsert) {
+      try {
+        XSKCsvRecordMetadata csvRecordMetadata = new XSKCsvRecordMetadata(csvRecord, tableModel, headerNames,
+            tableImportConfigurationDefinition.getDistinguishEmptyFromNull());
+        xskcsvRecordDao.save(csvRecordMetadata);
 
-                XSKImportedCSVRecordModel importedCSVRecordModel = new XSKImportedCSVRecordModel();
-                importedCSVRecordModel.setCsvLocation(tableImportConfigurationDefinition.getFile());
-                importedCSVRecordModel.setHash(getCSVRecordHash(csvRecord));
-                importedCSVRecordModel.setHdbtiLocation(tableImportConfigurationDefinition.getHdbtiFileName());
-                importedCSVRecordModel.setRowId(csvRecordMetadata.getCsvRecordPkValue());
-                importedCSVRecordModel.setTableName(tableName);
-                xskImportedCSVRecordDao.save(importedCSVRecordModel);
-            } catch (SQLException e) {
-                logger.error(csvRecord.toString());
-                logger.error("Error occurred while inserting the csv values in the table pointed by HDBTI file", e);
-                logger.error(format("Error occurred while processing %s for table %s at record %d",
-                        tableImportConfigurationDefinition.getFile(), tableImportConfigurationDefinition.getTable(),
-                        csvRecord.getRecordNumber()), e);
-            } catch (Exception e) {
-                logger.error(csvRecord.toString());
-                logger.error(format("Error occurred while processing %s for table %s at record %d",
-                        tableImportConfigurationDefinition.getFile(), tableImportConfigurationDefinition.getTable(),
-                        csvRecord.getRecordNumber()), e);
-            }
+        XSKImportedCSVRecordModel importedCSVRecordModel = new XSKImportedCSVRecordModel();
+        importedCSVRecordModel.setCsvLocation(tableImportConfigurationDefinition.getFile());
+        importedCSVRecordModel.setHash(getCSVRecordHash(csvRecord));
+        importedCSVRecordModel.setHdbtiLocation(tableImportConfigurationDefinition.getHdbtiFileName());
+        importedCSVRecordModel.setRowId(csvRecordMetadata.getCsvRecordPkValue());
+        importedCSVRecordModel.setTableName(tableName);
+        xskImportedCSVRecordDao.save(importedCSVRecordModel);
+      } catch (SQLException e) {
+        logger.error(csvRecord.toString());
+        logger.error("Error occurred while inserting the csv values in the table pointed by HDBTI file", e);
+        logger.error(format("Error occurred while processing %s for table %s at record %d",
+            tableImportConfigurationDefinition.getFile(), tableImportConfigurationDefinition.getTable(),
+            csvRecord.getRecordNumber()), e);
+      } catch (Exception e) {
+        logger.error(csvRecord.toString());
+        logger.error(format("Error occurred while processing %s for table %s at record %d",
+            tableImportConfigurationDefinition.getFile(), tableImportConfigurationDefinition.getTable(),
+            csvRecord.getRecordNumber()), e);
+      }
+    }
+  }
+
+  @Override
+  public Map<String, XSKImportedCSVRecordModel> getImportedCSVRecordsByTableAndCSVLocation(String tableName, String csvLocation)
+      throws XSKDataStructuresException {
+    return xskImportedCSVRecordDao.getImportedCSVRecordsByTableAndCSVLocation(tableName, csvLocation)
+        .stream()
+        .collect(Collectors.toMap(XSKImportedCSVRecordModel::getRowId, importModel -> importModel));
+  }
+
+  @Override
+  public void cleanUpHdbtiRelatedData() throws XSKTableImportException {
+    List<XSKTableImportArtifact> tableImportArtifacts = xskTableImportArtifactDao.getTableImportArtifacts();
+
+    for (XSKTableImportArtifact tableImportArtifact : tableImportArtifacts) {
+      if (tableImportArtifact.getType().equals(IXSKTableImportModel.TYPE_HDBTI)
+          && !repository.hasResource(XSKUtils.convertToFullPath(tableImportArtifact.getLocation()))) {
+        xskTableImportArtifactDao.removeTableImportArtifact(tableImportArtifact.getLocation());
+        xskCsvToHdbtiRelationDao.deleteCsvAndHdbtiRelations(tableImportArtifact.getLocation());
+        removeCSVRecordsFromDb(tableImportArtifact.getLocation());
+        logger
+            .warn("Cleaned up HDBTI file [{}] from location: {}", tableImportArtifact.getName(),
+                tableImportArtifact.getLocation());
+      }
+    }
+  }
+
+  @Override
+  public void updateCsvRecords(List<CSVRecord> csvRecords, List<String> headerNames,
+      List<XSKImportedCSVRecordModel> importedCsvRecordsToUpdate,
+      XSKTableImportConfigurationDefinition tableImportConfigurationDefinition) throws SQLException {
+    String tableName = convertToActualTableName(tableImportConfigurationDefinition.getTable());
+    PersistenceTableModel tableModel = dbMetadataUtil.getTableMetadata(tableName, XSKCommonsDBUtils.getTableSchema(dataSource, tableName));
+
+    for (CSVRecord csvRecord : csvRecords) {
+      try {
+        XSKCsvRecordMetadata csvRecordMetadata = new XSKCsvRecordMetadata(csvRecord, tableModel, headerNames,
+            tableImportConfigurationDefinition.getDistinguishEmptyFromNull());
+        xskcsvRecordDao.update(csvRecordMetadata);
+        for (XSKImportedCSVRecordModel importedCSVRecordModel : importedCsvRecordsToUpdate) {
+          xskImportedCSVRecordDao.update(importedCSVRecordModel);
         }
+      } catch (SQLException throwable) {
+        logger.error(throwable.getMessage(), throwable);
+      }
+    }
+  }
+
+  @Override
+  public void removeCsvRecords(List<XSKImportedCSVRecordModel> importedCSVRecordModels, String tableName) {
+    List<String> idsToRemove = importedCSVRecordModels.stream().map(XSKImportedCSVRecordModel::getRowId).collect(Collectors.toList());
+
+    try {
+      xskcsvRecordDao.deleteAll(idsToRemove, tableName);
+      xskImportedCSVRecordDao.deleteAll(importedCSVRecordModels);
+    } catch (SQLException sqlException) {
+      logger.error(
+          String.format("An error occurred while trying to delete removed CSVs with ids: %s from table %s", String.join(",", idsToRemove),
+              tableName));
+    }
+  }
+
+  @Override
+  public void refreshCsvRelations(XSKTableImportArtifact tableImportArtifact) {
+    xskCsvToHdbtiRelationDao.deleteCsvAndHdbtiRelations(XSKUtils.convertToFullPath(tableImportArtifact.getLocation()));
+    xskCsvToHdbtiRelationDao.persistNewCsvAndHdbtiRelations(tableImportArtifact);
+  }
+
+  @Override
+  public String getPkForCSVRecord(CSVRecord csvRecord, String tableName, List<String> headerNames) {
+    List<PersistenceTableColumnModel> columnModels = getTableMetadata(tableName).getColumns();
+    if (headerNames.size() > 0) {
+      String pkColumnName = columnModels.stream().filter(PersistenceTableColumnModel::isPrimaryKey).findFirst().get().getName();
+      int csvRecordPkValueIndex = headerNames.indexOf(pkColumnName);
+      return csvRecord.get(csvRecordPkValueIndex);
     }
 
-    @Override
-    public Map<String, XSKImportedCSVRecordModel> getImportedCSVRecordsByTableAndCSVLocation(String tableName, String csvLocation) throws XSKDataStructuresException {
-        return xskImportedCSVRecordDao.getImportedCSVRecordsByTableAndCSVLocation(tableName, csvLocation)
-                .stream()
-                .collect(Collectors.toMap(XSKImportedCSVRecordModel::getRowId, importModel -> importModel));
+    for (int i = 0; i < csvRecord.size(); i++) {
+      boolean isColumnPk = columnModels.get(i).isPrimaryKey();
+      if (isColumnPk && !StringUtils.isEmpty(csvRecord.get(i))) {
+        return csvRecord.get(i);
+      }
     }
 
-    @Override
-    public void cleanUpHdbtiRelatedData() throws XSKTableImportException {
-        List<XSKTableImportArtifact> tableImportArtifacts = xskTableImportArtifactDao.getTableImportArtifacts();
+    return null;
+  }
 
-        for (XSKTableImportArtifact tableImportArtifact : tableImportArtifacts) {
-            if (tableImportArtifact.getType().equals(IXSKTableImportModel.TYPE_HDBTI)
-                    && !repository.hasResource(XSKUtils.convertToFullPath(tableImportArtifact.getLocation()))) {
-                xskTableImportArtifactDao.removeTableImportArtifact(tableImportArtifact.getLocation());
-                xskCsvToHdbtiRelationDao.deleteCsvAndHdbtiRelations(tableImportArtifact.getLocation());
-                removeCSVRecordsFromDb(tableImportArtifact.getLocation());
-                logger
-                        .warn("Cleaned up HDBTI file [{}] from location: {}", tableImportArtifact.getName(),
-                                tableImportArtifact.getLocation());
-            }
-        }
+  @Override
+  public String getCSVRecordHash(CSVRecord csvRecord) {
+    StringBuilder joinedValues = new StringBuilder();
+
+    for (int i = 0; i < csvRecord.size(); i++) {
+      joinedValues.append(csvRecord.get(i));
+      if (i != csvRecord.size() - 1) {
+        joinedValues.append(",");
+      }
     }
 
-    @Override
-    public void updateCsvRecords(List<CSVRecord> csvRecords, List<String> headerNames,
-                                 List<XSKImportedCSVRecordModel> importedCsvRecordsToUpdate,
-                                 XSKTableImportConfigurationDefinition tableImportConfigurationDefinition) throws SQLException {
-        String tableName = convertToActualTableName(tableImportConfigurationDefinition.getTable());
-        PersistenceTableModel tableModel = dbMetadataUtil.getTableMetadata(tableName, XSKCommonsDBUtils.getTableSchema(dataSource, tableName));
+    return DigestUtils.md5Hex(joinedValues.toString());
+  }
 
-        for (CSVRecord csvRecord : csvRecords) {
-            try {
-                XSKCsvRecordMetadata csvRecordMetadata = new XSKCsvRecordMetadata(csvRecord, tableModel, headerNames,
-                        tableImportConfigurationDefinition.getDistinguishEmptyFromNull());
-                xskcsvRecordDao.update(csvRecordMetadata);
-                for (XSKImportedCSVRecordModel importedCSVRecordModel : importedCsvRecordsToUpdate) {
-                    xskImportedCSVRecordDao.update(importedCSVRecordModel);
-                }
-            } catch (SQLException throwable) {
-                throwable.printStackTrace();
-            }
-        }
+  @Override
+  public String convertToActualTableName(String tableName) {
+    boolean caseSensitive = Boolean.parseBoolean(Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false"));
+    if (caseSensitive) {
+      tableName = "\"" + tableName + "\"";
     }
+    return tableName;
+  }
 
-    @Override
-    public void removeCsvRecords(List<XSKImportedCSVRecordModel> importedCSVRecordModels, String tableName) {
-        List<String> idsToRemove = importedCSVRecordModels.stream().map(XSKImportedCSVRecordModel::getRowId).collect(Collectors.toList());
+  @Override
+  public String convertToActualFileName(String fileNamePath) {
+    String fileName = fileNamePath.substring(fileNamePath.lastIndexOf(':') + 1);
 
-        try {
-            xskcsvRecordDao.deleteAll(idsToRemove, tableName);
-            xskImportedCSVRecordDao.deleteAll(importedCSVRecordModels);
-        } catch (SQLException sqlException) {
-            logger.error(String.format("An error occurred while trying to delete removed CSVs with ids: %s from table %s", String.join(",", idsToRemove), tableName));
-        }
+    return "/registry/public/" + fileNamePath.substring(0, fileNamePath.indexOf(':')).replaceAll("\\.", "/") + "/" + fileName;
+  }
+
+  private PersistenceTableModel getTableMetadata(String tableName) {
+    try {
+      return dbMetadataUtil.getTableMetadata(tableName, XSKCommonsDBUtils.getTableSchema(dataSource, tableName));
+    } catch (SQLException sqlException) {
+      logger.error(String.format("Error occurred while trying to read table metadata for table with name: %s", tableName), sqlException);
     }
+    return null;
+  }
 
-    @Override
-    public void refreshCsvRelations(XSKTableImportArtifact tableImportArtifact) {
-        xskCsvToHdbtiRelationDao.deleteCsvAndHdbtiRelations(XSKUtils.convertToFullPath(tableImportArtifact.getLocation()));
-        xskCsvToHdbtiRelationDao.persistNewCsvAndHdbtiRelations(tableImportArtifact);
+  private void removeCSVRecordsFromDb(String hdbtiLocation) {
+    List<XSKImportedCSVRecordModel> csvRecordsToRemove = xskImportedCSVRecordDao.getImportedCSVsByHdbtiLocation(hdbtiLocation);
+    csvRecordsToRemove.sort(Comparator.comparing(XSKImportedCSVRecordModel::getCreatedAt, Comparator.reverseOrder()));
+    try {
+      for (XSKImportedCSVRecordModel csvRecord :
+          csvRecordsToRemove) {
+        xskcsvRecordDao.delete(csvRecord.getRowId(), csvRecord.getTableName());
+      }
+
+      xskImportedCSVRecordDao.deleteAll(csvRecordsToRemove);
+    } catch (SQLException sqlException) {
+      logger.error(
+          String.format("Error occurred while trying to remove imported csv records after a deletion of an hdbti file with location: %s",
+              hdbtiLocation), sqlException);
     }
-
-    @Override
-    public String getPkForCSVRecord(CSVRecord csvRecord, String tableName, List<String> headerNames) {
-        List<PersistenceTableColumnModel> columnModels = getTableMetadata(tableName).getColumns();
-        if (headerNames.size() > 0) {
-            String pkColumnName = columnModels.stream().filter(PersistenceTableColumnModel::isPrimaryKey).findFirst().get().getName();
-            int csvRecordPkValueIndex = headerNames.indexOf(pkColumnName);
-            return csvRecord.get(csvRecordPkValueIndex);
-        }
-
-        for (int i = 0; i < csvRecord.size(); i++) {
-            boolean isColumnPk = columnModels.get(i).isPrimaryKey();
-            if (isColumnPk && !StringUtils.isEmpty(csvRecord.get(i))) {
-                return csvRecord.get(i);
-            }
-        }
-
-        return null;
-    }
-
-    @Override
-    public String getCSVRecordHash(CSVRecord csvRecord) {
-        StringBuilder joinedValues = new StringBuilder();
-
-        for (int i = 0; i < csvRecord.size(); i++) {
-            joinedValues.append(csvRecord.get(i));
-            if (i != csvRecord.size() - 1) {
-                joinedValues.append(",");
-            }
-        }
-
-        return DigestUtils.md5Hex(joinedValues.toString());
-    }
-
-    @Override
-    public String convertToActualTableName(String tableName) {
-        boolean caseSensitive = Boolean.parseBoolean(Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false"));
-        if (caseSensitive) {
-            tableName = "\"" + tableName + "\"";
-        }
-        return tableName;
-    }
-
-    @Override
-    public String convertToActualFileName(String fileNamePath) {
-        String fileName = fileNamePath.substring(fileNamePath.lastIndexOf(':') + 1);
-
-        return "/registry/public/" + fileNamePath.substring(0, fileNamePath.indexOf(':')).replaceAll("\\.", "/") + "/" + fileName;
-    }
-
-    private PersistenceTableModel getTableMetadata(String tableName) {
-        try {
-            return dbMetadataUtil.getTableMetadata(tableName, XSKCommonsDBUtils.getTableSchema(dataSource, tableName));
-        } catch (SQLException sqlException) {
-            logger.error(String.format("Error occurred while trying to read table metadata for table with name: %s", tableName), sqlException);
-        }
-        return null;
-    }
-
-    private void removeCSVRecordsFromDb(String hdbtiLocation) {
-        List<XSKImportedCSVRecordModel> csvRecordsToRemove = xskImportedCSVRecordDao.getImportedCSVsByHdbtiLocation(hdbtiLocation);
-        csvRecordsToRemove.sort(Comparator.comparing(XSKImportedCSVRecordModel::getCreatedAt, Comparator.reverseOrder()));
-        try {
-            for (XSKImportedCSVRecordModel csvRecord :
-                    csvRecordsToRemove) {
-                xskcsvRecordDao.delete(csvRecord.getRowId(), csvRecord.getTableName());
-            }
-
-            xskImportedCSVRecordDao.deleteAll(csvRecordsToRemove);
-        } catch (SQLException sqlException) {
-            logger.error(String.format("Error occurred while trying to remove imported csv records after a deletion of an hdbti file with location: %s", hdbtiLocation), sqlException);
-        }
-    }
+  }
 }

--- a/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/synchronizer/XSKTableImportSynchronizer.java
+++ b/modules/engines/engine-hdbti/src/main/java/com/sap/xsk/hdbti/synchronizer/XSKTableImportSynchronizer.java
@@ -74,7 +74,7 @@ public class XSKTableImportSynchronizer extends AbstractSynchronizer {
 
   private DataSource dataSource = (DataSource) StaticObjects.get(StaticObjects.DATASOURCE);
   private IXSKTableImportParser xskTableImportParser = new XSKTableImportParser();
-  private IXSKHDBTIProcessor xskHdbtiProcessor =  new XSKHDBTIProcessor();
+  private IXSKHDBTIProcessor xskHdbtiProcessor = new XSKHDBTIProcessor();
   private IXSKCsvToHdbtiRelationDao xskCsvToHdbtiRelationDao = new XSKCsvToHdbtiRelationDao();
   private IXSKTableImportArtifactDao xskTableImportArtifactDao = new XSKTableImportArtifactDao();
   private IXSKHDBTICoreService xskHdbtiCoreService = new XSKHDBTICoreService();
@@ -148,7 +148,7 @@ public class XSKTableImportSynchronizer extends AbstractSynchronizer {
       } catch (XSKArtifactParserException parserException) {
         logger.error(parserException.getMessage());
       } catch (SQLException throwables) {
-        throwables.printStackTrace();
+        logger.error(throwables.getMessage(), throwables);
       }
     } else if (resourceName.endsWith(IXSKTableImportModel.FILE_EXTENSION_CSV)) {
       List<XSKTableImportToCsvRelation> affectedHdbtiToCsvRelations = xskCsvToHdbtiRelationDao
@@ -214,7 +214,7 @@ public class XSKTableImportSynchronizer extends AbstractSynchronizer {
         HDBTI_SYNCHRONIZED.add(xskTableImportArtifact.getLocation());
       }
     } catch (XSKTableImportException e) {
-      e.printStackTrace();
+      logger.error(e.getMessage(), e);
     }
   }
 

--- a/modules/engines/engine-hdbti/src/test/java/com/sap/xsk/hdbti/processors/XSKHDBTIProcessorTest.java
+++ b/modules/engines/engine-hdbti/src/test/java/com/sap/xsk/hdbti/processors/XSKHDBTIProcessorTest.java
@@ -52,548 +52,554 @@ import org.eclipse.dirigible.database.persistence.PersistenceManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class XSKHDBTIProcessorTest {
 
-    private static final String STUDENTS_CSV_LOCATION = "registry/public/university/students/students.csv";
-    public static final String HDBTI_LOCATION = "university/data/Students.hdbti";
-    public static final String CSV_FILE_LOCATION = "university.students:students.csv";
-    public static final String STUDENTS_TABLE_NAME = "STUDENTS";
+  private static final Logger logger = LoggerFactory.getLogger(XSKHDBTIProcessorTest.class);
 
-    private DataSource datasource;
-    private DataSource systemDatasource;
-    private IXSKHDBTIProcessor processor;
-    private IXSKHDBTICoreService xskHdbtiCoreService;
-    private final PersistenceManager<Student> studentManager = new PersistenceManager<>();
-    private final PersistenceManager<XSKImportedCSVRecordModel> importedCsvRecordsManager = new PersistenceManager<>();
-    private final PersistenceManager<XSKTableImportArtifact> importArtifactManager = new PersistenceManager<>();
-    private final PersistenceManager<XSKTableImportToCsvRelation> importToCsvRelationManager = new PersistenceManager<>();
+  private static final String STUDENTS_CSV_LOCATION = "registry/public/university/students/students.csv";
+  public static final String HDBTI_LOCATION = "university/data/Students.hdbti";
+  public static final String CSV_FILE_LOCATION = "university.students:students.csv";
+  public static final String STUDENTS_TABLE_NAME = "STUDENTS";
 
-    @Before
-    public void setUp() throws SQLException {
-        HdbtiTestModule hdbtiTestModule = new HdbtiTestModule();
-        hdbtiTestModule.configure();
-        datasource = (DataSource) StaticObjects.get(StaticObjects.DATASOURCE);
-        systemDatasource = (DataSource) StaticObjects.get(StaticObjects.SYSTEM_DATASOURCE);
-        processor = new XSKHDBTIProcessor();
-        xskHdbtiCoreService = new XSKHDBTICoreService();
-        try (Connection connection = datasource.getConnection()) {
-            studentManager.tableCreate(connection, Student.class);
-        }
+  private DataSource datasource;
+  private DataSource systemDatasource;
+  private IXSKHDBTIProcessor processor;
+  private IXSKHDBTICoreService xskHdbtiCoreService;
+  private final PersistenceManager<Student> studentManager = new PersistenceManager<>();
+  private final PersistenceManager<XSKImportedCSVRecordModel> importedCsvRecordsManager = new PersistenceManager<>();
+  private final PersistenceManager<XSKTableImportArtifact> importArtifactManager = new PersistenceManager<>();
+  private final PersistenceManager<XSKTableImportToCsvRelation> importToCsvRelationManager = new PersistenceManager<>();
+
+  @Before
+  public void setUp() throws SQLException {
+    HdbtiTestModule hdbtiTestModule = new HdbtiTestModule();
+    hdbtiTestModule.configure();
+    datasource = (DataSource) StaticObjects.get(StaticObjects.DATASOURCE);
+    systemDatasource = (DataSource) StaticObjects.get(StaticObjects.SYSTEM_DATASOURCE);
+    processor = new XSKHDBTIProcessor();
+    xskHdbtiCoreService = new XSKHDBTICoreService();
+    try (Connection connection = datasource.getConnection()) {
+      studentManager.tableCreate(connection, Student.class);
     }
+  }
 
-    @After
-    public void cleanup() throws SQLException {
-        try (Connection connection = datasource.getConnection()) {
-            if (studentManager.tableExists(connection, Student.class)) {            	
-            	studentManager.tableDrop(connection, Student.class);
-            }
-        }
-        try (Connection connection = systemDatasource.getConnection()) {        	
-        	if (importedCsvRecordsManager.tableExists(connection, XSKImportedCSVRecordModel.class)) {
-        		importedCsvRecordsManager.tableDrop(connection, XSKImportedCSVRecordModel.class);        		
-        	}
-        }
+  @After
+  public void cleanup() throws SQLException {
+    try (Connection connection = datasource.getConnection()) {
+      if (studentManager.tableExists(connection, Student.class)) {
+        studentManager.tableDrop(connection, Student.class);
+      }
     }
-
-    @Test
-    public void testDataImportedCorrectly()
-        throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
-        writeToFile(STUDENTS_CSV_LOCATION, getInitialContent());
-        XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
-        importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
-        importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
-        importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
-
-        try (Connection connection = datasource.getConnection()) {
-            processor.process(importConfigurationDefinition, connection);
-            List<Student> students = studentManager.findAll(connection, Student.class);
-            assertCorrectDataImported(students);
-        }
-        try (Connection connection = systemDatasource.getConnection()) {            	
-        	List<XSKImportedCSVRecordModel> importedCsvRecords = importedCsvRecordsManager.findAll(connection, XSKImportedCSVRecordModel.class);
-        	assertCorrectCsvRecordMetadataImported(importedCsvRecords);
-        	writeToFile(STUDENTS_CSV_LOCATION, "");
-        }
+    try (Connection connection = systemDatasource.getConnection()) {
+      if (importedCsvRecordsManager.tableExists(connection, XSKImportedCSVRecordModel.class)) {
+        importedCsvRecordsManager.tableDrop(connection, XSKImportedCSVRecordModel.class);
+      }
     }
+  }
 
-    @Test
-    public void testChangeOfDataProperlyReflectedInDb()
-        throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
-        XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
-        importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
-        importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
-        importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
+  @Test
+  public void testDataImportedCorrectly()
+      throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
+    writeToFile(STUDENTS_CSV_LOCATION, getInitialContent());
+    XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
+    importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
+    importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
+    importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
 
-        try (Connection connection = datasource.getConnection()) {
-            writeToFile(STUDENTS_CSV_LOCATION, getInitialContent());
-            processor.process(importConfigurationDefinition, connection);
-
-            writeToFile(STUDENTS_CSV_LOCATION, "");
-            writeToFile(STUDENTS_CSV_LOCATION, getUpdatedContent());
-            processor.process(importConfigurationDefinition, connection);
-
-            List<Student> students1 = studentManager.findAll(connection, Student.class);
-            assertEquals("Changed", students1.get(1).getFirstName());
-            assertEquals("Changed", students1.get(1).getLastName());
-            assertEquals(Timestamp.valueOf("2018-09-21 14:00:12"), students1.get(1).getSigned());
-        }
+    try (Connection connection = datasource.getConnection()) {
+      processor.process(importConfigurationDefinition, connection);
+      List<Student> students = studentManager.findAll(connection, Student.class);
+      assertCorrectDataImported(students);
     }
-
-    @Test
-    public void testCsvRecordRemovedFromCsvFileShouldRemoveFromDb()
-        throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
-        XSKTableImportConfigurationDefinition importConfigurationDefinitionWithRemovedRecord = new XSKTableImportConfigurationDefinition();
-        importConfigurationDefinitionWithRemovedRecord.setFile(CSV_FILE_LOCATION);
-        importConfigurationDefinitionWithRemovedRecord.setHdbtiFileName(HDBTI_LOCATION);
-        importConfigurationDefinitionWithRemovedRecord.setTable(STUDENTS_TABLE_NAME);
-
-        try (Connection connection = datasource.getConnection()) {
-            writeToFile(STUDENTS_CSV_LOCATION, getInitialContent());
-            processor.process(importConfigurationDefinitionWithRemovedRecord, connection);
-
-            writeToFile(STUDENTS_CSV_LOCATION, "");
-            writeToFile(STUDENTS_CSV_LOCATION, getRemovedContent());
-            processor.process(importConfigurationDefinitionWithRemovedRecord, connection);
-
-            List<Student> students = studentManager.findAll(connection, Student.class);
-            assertEquals(2, students.size());
-
-
-            Student deletedStudent = studentManager.find(connection, Student.class, 1L);
-            assertNull(deletedStudent);
-            List<XSKImportedCSVRecordModel> importedCSVRecordModel = importedCsvRecordsManager.findAll(connection, XSKImportedCSVRecordModel.class);
-            boolean isCsvRecordRemovedFromMetadataTable = importedCSVRecordModel.stream().anyMatch(i -> i.getRowId().equals("1"));
-            assertFalse(isCsvRecordRemovedFromMetadataTable);
-        }
-        try (Connection connection = systemDatasource.getConnection()) {        	
-        	List<XSKImportedCSVRecordModel> importedCsvRecords = importedCsvRecordsManager.findAll(connection, XSKImportedCSVRecordModel.class);
-        	assertEquals(2, importedCsvRecords.size());
-        	writeToFile(STUDENTS_CSV_LOCATION, "");
-        }
+    try (Connection connection = systemDatasource.getConnection()) {
+      List<XSKImportedCSVRecordModel> importedCsvRecords = importedCsvRecordsManager.findAll(connection, XSKImportedCSVRecordModel.class);
+      assertCorrectCsvRecordMetadataImported(importedCsvRecords);
+      writeToFile(STUDENTS_CSV_LOCATION, "");
     }
+  }
 
-    @Test
-    public void testCsvRecordAddedShouldReflectDataInDb()
-        throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
-        XSKTableImportConfigurationDefinition importConfigurationDefinitionWithRemovedRecord = new XSKTableImportConfigurationDefinition();
-        importConfigurationDefinitionWithRemovedRecord.setFile(CSV_FILE_LOCATION);
-        importConfigurationDefinitionWithRemovedRecord.setHdbtiFileName(HDBTI_LOCATION);
-        importConfigurationDefinitionWithRemovedRecord.setTable(STUDENTS_TABLE_NAME);
+  @Test
+  public void testChangeOfDataProperlyReflectedInDb()
+      throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
+    XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
+    importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
+    importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
+    importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
 
-        try (Connection connection = datasource.getConnection()) {
-            writeToFile(STUDENTS_CSV_LOCATION, getInitialContent());
-            processor.process(importConfigurationDefinitionWithRemovedRecord, connection);
+    try (Connection connection = datasource.getConnection()) {
+      writeToFile(STUDENTS_CSV_LOCATION, getInitialContent());
+      processor.process(importConfigurationDefinition, connection);
 
-            writeToFile(STUDENTS_CSV_LOCATION, "");
-            writeToFile(STUDENTS_CSV_LOCATION, getAddedContent());
+      writeToFile(STUDENTS_CSV_LOCATION, "");
+      writeToFile(STUDENTS_CSV_LOCATION, getUpdatedContent());
+      processor.process(importConfigurationDefinition, connection);
 
-            processor.process(importConfigurationDefinitionWithRemovedRecord, connection);
-
-            List<Student> students = studentManager.findAll(connection, Student.class);
-            assertEquals(4, students.size());
-        }
-        try (Connection connection = systemDatasource.getConnection()) {        	
-        	List<XSKImportedCSVRecordModel> importedCSVRecordModel = importedCsvRecordsManager.findAll(connection, XSKImportedCSVRecordModel.class);
-        	assertEquals(4, importedCSVRecordModel.size());
-        	writeToFile(STUDENTS_CSV_LOCATION, "");
-        }
+      List<Student> students1 = studentManager.findAll(connection, Student.class);
+      assertEquals("Changed", students1.get(1).getFirstName());
+      assertEquals("Changed", students1.get(1).getLastName());
+      assertEquals(Timestamp.valueOf("2018-09-21 14:00:12"), students1.get(1).getSigned());
     }
+  }
 
-    @Test
-    public void testCsvRecordWithCustomDelimFieldDelimEnclosingAndEscapeCharShouldInsertProperData()
-        throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
-        XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
-        importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
-        importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
-        importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
-        importConfigurationDefinition.setDelimEnclosing("'");
-        importConfigurationDefinition.setDelimField(";");
+  @Test
+  public void testCsvRecordRemovedFromCsvFileShouldRemoveFromDb()
+      throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
+    XSKTableImportConfigurationDefinition importConfigurationDefinitionWithRemovedRecord = new XSKTableImportConfigurationDefinition();
+    importConfigurationDefinitionWithRemovedRecord.setFile(CSV_FILE_LOCATION);
+    importConfigurationDefinitionWithRemovedRecord.setHdbtiFileName(HDBTI_LOCATION);
+    importConfigurationDefinitionWithRemovedRecord.setTable(STUDENTS_TABLE_NAME);
 
-        try (Connection connection = datasource.getConnection()) {
-            writeToFile(STUDENTS_CSV_LOCATION, getQuoteContent());
-            processor.process(importConfigurationDefinition, connection);
-            List<Student> students = studentManager.findAll(connection, Student.class);
-            assertEquals(1, students.size());
-            assertEquals("Georgi, 'Junior'", students.get(0).getFirstName());
+    try (Connection connection = datasource.getConnection()) {
+      writeToFile(STUDENTS_CSV_LOCATION, getInitialContent());
+      processor.process(importConfigurationDefinitionWithRemovedRecord, connection);
 
-            writeToFile(STUDENTS_CSV_LOCATION, "");
-        }
+      writeToFile(STUDENTS_CSV_LOCATION, "");
+      writeToFile(STUDENTS_CSV_LOCATION, getRemovedContent());
+      processor.process(importConfigurationDefinitionWithRemovedRecord, connection);
+
+      List<Student> students = studentManager.findAll(connection, Student.class);
+      assertEquals(2, students.size());
+
+      Student deletedStudent = studentManager.find(connection, Student.class, 1L);
+      assertNull(deletedStudent);
+      List<XSKImportedCSVRecordModel> importedCSVRecordModel = importedCsvRecordsManager.findAll(connection,
+          XSKImportedCSVRecordModel.class);
+      boolean isCsvRecordRemovedFromMetadataTable = importedCSVRecordModel.stream().anyMatch(i -> i.getRowId().equals("1"));
+      assertFalse(isCsvRecordRemovedFromMetadataTable);
     }
-
-    @Test
-    public void testInsertCsvRecordWithHeaders()
-        throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
-        XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
-        importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
-        importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
-        importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
-        importConfigurationDefinition.setHeader(true);
-
-        try (Connection connection = datasource.getConnection()) {
-            writeToFile(STUDENTS_CSV_LOCATION, getInitialContentWithHeaders());
-            processor.process(importConfigurationDefinition, connection);
-            List<Student> students = studentManager.findAll(connection, Student.class);
-            assertCorrectDataImported(students);
-
-        }
-        try (Connection connection = systemDatasource.getConnection()) {        	
-        	List<XSKImportedCSVRecordModel> importedCsvRecords = importedCsvRecordsManager.findAll(connection, XSKImportedCSVRecordModel.class);
-        	assertCorrectCsvRecordMetadataImported(importedCsvRecords);
-        	writeToFile(STUDENTS_CSV_LOCATION, "");
-        }
+    try (Connection connection = systemDatasource.getConnection()) {
+      List<XSKImportedCSVRecordModel> importedCsvRecords = importedCsvRecordsManager.findAll(connection, XSKImportedCSVRecordModel.class);
+      assertEquals(2, importedCsvRecords.size());
+      writeToFile(STUDENTS_CSV_LOCATION, "");
     }
+  }
 
-    @Test
-    public void testUpdateCsvRecordWithHeadersShouldReflectDbData()
-        throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
-        XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
-        importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
-        importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
-        importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
-        importConfigurationDefinition.setHeader(true);
+  @Test
+  public void testCsvRecordAddedShouldReflectDataInDb()
+      throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
+    XSKTableImportConfigurationDefinition importConfigurationDefinitionWithRemovedRecord = new XSKTableImportConfigurationDefinition();
+    importConfigurationDefinitionWithRemovedRecord.setFile(CSV_FILE_LOCATION);
+    importConfigurationDefinitionWithRemovedRecord.setHdbtiFileName(HDBTI_LOCATION);
+    importConfigurationDefinitionWithRemovedRecord.setTable(STUDENTS_TABLE_NAME);
 
-        try (Connection connection = datasource.getConnection()) {
-            writeToFile(STUDENTS_CSV_LOCATION, getInitialContentWithHeaders());
-            processor.process(importConfigurationDefinition, connection);
+    try (Connection connection = datasource.getConnection()) {
+      writeToFile(STUDENTS_CSV_LOCATION, getInitialContent());
+      processor.process(importConfigurationDefinitionWithRemovedRecord, connection);
 
-            writeToFile(STUDENTS_CSV_LOCATION, "");
-            writeToFile(STUDENTS_CSV_LOCATION, getChangedContentWithHeaders());
-            processor.process(importConfigurationDefinition, connection);
+      writeToFile(STUDENTS_CSV_LOCATION, "");
+      writeToFile(STUDENTS_CSV_LOCATION, getAddedContent());
 
-            List<Student> students = studentManager.findAll(connection, Student.class);
-            assertEquals("Changed", students.get(0).getFirstName());
-            assertEquals("Changed", students.get(0).getLastName());
-            assertEquals(25L, students.get(0).getAge().longValue());
+      processor.process(importConfigurationDefinitionWithRemovedRecord, connection);
 
-            assertEquals("Changed", students.get(1).getFirstName());
-            assertEquals("Changed", students.get(1).getLastName());
-            assertEquals(25L, students.get(1).getAge().longValue());
-
-            assertEquals("Changed", students.get(2).getFirstName());
-            assertEquals("Changed", students.get(2).getLastName());
-            assertEquals(25L, students.get(2).getAge().longValue());
-
-            writeToFile(STUDENTS_CSV_LOCATION, "");
-        }
+      List<Student> students = studentManager.findAll(connection, Student.class);
+      assertEquals(4, students.size());
     }
-
-    @Test
-    public void testCleanUpDeletesEverythingRelatedToHdbtiFile()
-        throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
-        XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
-        importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
-        importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
-        importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
-
-        try (Connection connection = systemDatasource.getConnection()) {
-        	writeToFile(STUDENTS_CSV_LOCATION, getInitialContent());
-        	importArtifactManager.insert(connection, getTableImportArtifact());
-        	importToCsvRelationManager.insert(connection, getXskTableImportToCsvRelation());
-        	importToCsvRelationManager.insert(connection, getXskTableImportToCsvRelation());        	
-        }
-        try (Connection connection = datasource.getConnection()) {
-            processor.process(importConfigurationDefinition, connection);
-            xskHdbtiCoreService.cleanUpHdbtiRelatedData();
-            List<Student> students = studentManager.findAll(connection, Student.class);
-            assertEquals(0, students.size());
-        }
-        try (Connection connection = systemDatasource.getConnection()) {        	
-        	List<XSKTableImportToCsvRelation> csvRelations = importToCsvRelationManager.findAll(connection, XSKTableImportToCsvRelation.class);
-        	List<XSKTableImportArtifact> importArtifacts = importArtifactManager.findAll(connection, XSKTableImportArtifact.class);
-        	List<XSKImportedCSVRecordModel> importedCSVRecordModels = importedCsvRecordsManager
-        			.findAll(connection, XSKImportedCSVRecordModel.class);
-
-        	assertEquals(0, csvRelations.size());
-        	assertEquals(0, importArtifacts.size());
-        	assertEquals(0, importedCSVRecordModels.size());
-        }
+    try (Connection connection = systemDatasource.getConnection()) {
+      List<XSKImportedCSVRecordModel> importedCSVRecordModel = importedCsvRecordsManager.findAll(connection,
+          XSKImportedCSVRecordModel.class);
+      assertEquals(4, importedCSVRecordModel.size());
+      writeToFile(STUDENTS_CSV_LOCATION, "");
     }
+  }
 
-    private XSKTableImportToCsvRelation getXskTableImportToCsvRelation() {
-        XSKTableImportToCsvRelation csvRelation = new XSKTableImportToCsvRelation();
-        csvRelation.setCsv(CSV_FILE_LOCATION);
-        csvRelation.setHdbti(HDBTI_LOCATION);
-        csvRelation.setCsvHash("H@sh!");
-        return csvRelation;
+  @Test
+  public void testCsvRecordWithCustomDelimFieldDelimEnclosingAndEscapeCharShouldInsertProperData()
+      throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
+    XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
+    importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
+    importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
+    importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
+    importConfigurationDefinition.setDelimEnclosing("'");
+    importConfigurationDefinition.setDelimField(";");
+
+    try (Connection connection = datasource.getConnection()) {
+      writeToFile(STUDENTS_CSV_LOCATION, getQuoteContent());
+      processor.process(importConfigurationDefinition, connection);
+      List<Student> students = studentManager.findAll(connection, Student.class);
+      assertEquals(1, students.size());
+      assertEquals("Georgi, 'Junior'", students.get(0).getFirstName());
+
+      writeToFile(STUDENTS_CSV_LOCATION, "");
     }
+  }
 
-    private XSKTableImportArtifact getTableImportArtifact() {
-        XSKTableImportArtifact xskTableImportArtifact = new XSKTableImportArtifact();
-        xskTableImportArtifact.setLocation(HDBTI_LOCATION);
-        xskTableImportArtifact.setName("DS_NAME");
-        xskTableImportArtifact.setType(IXSKTableImportModel.TYPE_HDBTI);
-        xskTableImportArtifact.setCreatedBy("TestUser");
-        xskTableImportArtifact.setHash("H@sh!");
-        xskTableImportArtifact.setCreatedAt(new Timestamp(new Date().getTime()));
-        return xskTableImportArtifact;
-    }
+  @Test
+  public void testInsertCsvRecordWithHeaders()
+      throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
+    XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
+    importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
+    importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
+    importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
+    importConfigurationDefinition.setHeader(true);
 
-    private void assertCorrectDataImported(List<Student> students) {
-        int importedStudentsCount = 3;
-        assertEquals(importedStudentsCount, students.size());
-        assertEquals(1L, students.get(0).getId().longValue());
-        assertEquals("Georgi", students.get(0).getFirstName());
-        assertEquals("Georgiev", students.get(0).getLastName());
-        assertEquals(27L, students.get(0).getAge().longValue());
-        assertEquals(Timestamp.valueOf("2017-09-20 14:00:12"), students.get(0).getSigned());
-
-        assertEquals(2L, students.get(1).getId().longValue());
-        assertEquals("Sara", students.get(1).getFirstName());
-        assertEquals("Toshkova", students.get(1).getLastName());
-        assertEquals(21L, students.get(1).getAge().longValue());
-        assertEquals(Timestamp.valueOf("2019-09-21 14:00:12"), students.get(1).getSigned());
-
-        assertEquals(3L, students.get(2).getId().longValue());
-        assertEquals("Toshko", students.get(2).getFirstName());
-        assertEquals("Ivanov", students.get(2).getLastName());
-        assertEquals(25L, students.get(2).getAge().longValue());
-        assertEquals(Timestamp.valueOf("2018-09-23 14:00:12"), students.get(2).getSigned());
-    }
-
-    private void assertCorrectCsvRecordMetadataImported(List<XSKImportedCSVRecordModel> importedCsvRecords) {
-        assertEquals(3, importedCsvRecords.size());
-
-        assertEquals("1", importedCsvRecords.get(0).getRowId());
-        assertEquals("STUDENTS", importedCsvRecords.get(0).getTableName());
-        assertEquals("university.students:students.csv", importedCsvRecords.get(0).getCsvLocation());
-        assertEquals(HDBTI_LOCATION, importedCsvRecords.get(0).getHdbtiLocation());
-
-        assertEquals("2", importedCsvRecords.get(1).getRowId());
-        assertEquals("STUDENTS", importedCsvRecords.get(1).getTableName());
-        assertEquals("university.students:students.csv", importedCsvRecords.get(1).getCsvLocation());
-        assertEquals(HDBTI_LOCATION, importedCsvRecords.get(1).getHdbtiLocation());
-
-        assertEquals("3", importedCsvRecords.get(2).getRowId());
-        assertEquals("STUDENTS", importedCsvRecords.get(2).getTableName());
-        assertEquals("university.students:students.csv", importedCsvRecords.get(2).getCsvLocation());
-        assertEquals(HDBTI_LOCATION, importedCsvRecords.get(2).getHdbtiLocation());
-    }
-
-    private String getInitialContent() {
-        return "1,Georgi,Georgiev,27,2017-09-20 14:00:12" + System.lineSeparator()
-                + "2,Sara,Toshkova,21,2019-09-21 14:00:12" + System.lineSeparator()
-                + "3,Toshko,Ivanov,25,2018-09-23 14:00:12" + System.lineSeparator();
-    }
-
-    private String getInitialContentWithHeaders() {
-        return "\"LAST_NAME\",\"FIRST_NAME\",\"ID\",\"AGE\",\"SIGNED\"" + System.lineSeparator()
-                + "Georgiev,Georgi,1,27,2017-09-20 14:00:12" + System.lineSeparator()
-                + "Toshkova,Sara,2,21,2019-09-21 14:00:12" + System.lineSeparator()
-                + "Ivanov,Toshko,3,25,2018-09-23 14:00:12" + System.lineSeparator();
-    }
-
-    private String getChangedContentWithHeaders() {
-        return "\"LAST_NAME\",\"FIRST_NAME\",\"ID\",\"AGE\",\"SIGNED\"" + System.lineSeparator()
-                + "Changed,Changed,1,25,2017-09-20 14:00:12" + System.lineSeparator()
-                + "Changed,Changed,2,25,2019-09-21 14:00:12" + System.lineSeparator()
-                + "Changed,Changed,3,25,2018-09-23 14:00:12" + System.lineSeparator();
-    }
-
-    private String getQuoteContent() {
-        return "1;'Georgi, \\'Junior\\'';Georgiev;27;2017-09-20 14:00:12" + System.lineSeparator();
-    }
-
-    private String getAddedContent() {
-        return "1,Georgi,Georgiev,27,2017-09-20 14:00:12" + System.lineSeparator()
-                + "2,Sara,Toshkova,21,2019-09-21 14:00:12" + System.lineSeparator()
-                + "3,Toshko,Ivanov,25,2018-09-23 14:00:12" + System.lineSeparator()
-                + "4,Pesho,Peshev,25,2014-09-23 13:10:12" + System.lineSeparator();
-    }
-
-    private String getUpdatedContent() {
-        return "1,Georgi,Georgiev,27,2017-09-20 14:00:12" + System.lineSeparator()
-                + "2,Changed,Changed,21,2018-09-21 14:00:12" + System.lineSeparator()
-                + "3,Toshko,Ivanov,25,2018-09-23 14:00:12" + System.lineSeparator();
-    }
-
-    private String getRemovedContent() {
-        return "2,Sara,Toshkova,21,2019-09-21 14:00:12" + System.lineSeparator()
-                + "3,Toshko,Ivanov,25,2018-09-23 14:00:12" + System.lineSeparator();
-    }
-
-    private void writeToFile(String path, String content) {
-        File fileToBeModified = getFileFromResource(path);
-        try {
-            assert fileToBeModified != null;
-            try (FileWriter fileWriter = new FileWriter(fileToBeModified)) {
-                fileWriter.write(content);
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private File getFileFromResource(String fileName) {
-
-        ClassLoader classLoader = getClass().getClassLoader();
-        URL resource = classLoader.getResource(fileName);
-        if (resource == null) {
-            throw new IllegalArgumentException("file not found! " + fileName);
-        } else {
-
-            // failed if files have whitespaces or special characters
-            //return new File(resource.getFile());
-
-            try {
-                return new File(resource.toURI());
-            } catch (URISyntaxException e) {
-                e.printStackTrace();
-            }
-
-            return null;
-        }
+    try (Connection connection = datasource.getConnection()) {
+      writeToFile(STUDENTS_CSV_LOCATION, getInitialContentWithHeaders());
+      processor.process(importConfigurationDefinition, connection);
+      List<Student> students = studentManager.findAll(connection, Student.class);
+      assertCorrectDataImported(students);
 
     }
+    try (Connection connection = systemDatasource.getConnection()) {
+      List<XSKImportedCSVRecordModel> importedCsvRecords = importedCsvRecordsManager.findAll(connection, XSKImportedCSVRecordModel.class);
+      assertCorrectCsvRecordMetadataImported(importedCsvRecords);
+      writeToFile(STUDENTS_CSV_LOCATION, "");
+    }
+  }
 
-    @Test
-    public void testParseHdbtiToJSONSuccessfully()
-            throws IOException, XSKArtifactParserException, XSKHDBTISyntaxErrorException, ProblemsException {
-        String hdbtiSample = org.apache.commons.io.IOUtils
-                .toString(XSKHDBTIProcessorTest.class.getResourceAsStream("/randomOrder.hdbti"), StandardCharsets.UTF_8);
+  @Test
+  public void testUpdateCsvRecordWithHeadersShouldReflectDbData()
+      throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
+    XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
+    importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
+    importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
+    importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
+    importConfigurationDefinition.setHeader(true);
 
-        List<XSKHDBTIImportConfigModel> model = processor.parseHdbtiToJSON("randomOrder.hdbti", hdbtiSample.getBytes(StandardCharsets.UTF_8));
-        assertEquals(model.size(), 2);
+    try (Connection connection = datasource.getConnection()) {
+      writeToFile(STUDENTS_CSV_LOCATION, getInitialContentWithHeaders());
+      processor.process(importConfigurationDefinition, connection);
 
-        XSKHDBTIImportConfigModel import1 = model.get(0);
-        assertEquals(import1.getDelimEnclosing(), "\"");
-        assertEquals(import1.getSchemaName(), "mySchema");
-        assertTrue(import1.getDistinguishEmptyFromNull());
-        assertFalse(import1.getHeader());
-        assertEquals(import1.getTableName(), "myTable");
-        assertFalse(import1.getUseHeaderNames());
-        assertEquals(import1.getDelimField(), ";");
-        assertEquals(import1.getFileName(), "/sap/ti2/demo/myData.csv");
-        assertEquals(import1.getKeys().size(), 1);
-        assertEquals(import1.getKeys().get(0).getColumn(), "GROUP_TYPE");
-        assertEquals(import1.getKeys().get(0).getValues().size(), 3);
-        assertEquals(import1.getKeys().get(0).getValues().get(0), "BW_CUBE");
-        assertEquals(import1.getKeys().get(0).getValues().get(1), "BW_DSO");
-        assertEquals(import1.getKeys().get(0).getValues().get(2), "BW_PSA");
+      writeToFile(STUDENTS_CSV_LOCATION, "");
+      writeToFile(STUDENTS_CSV_LOCATION, getChangedContentWithHeaders());
+      processor.process(importConfigurationDefinition, connection);
 
-        XSKHDBTIImportConfigModel import2 = model.get(1);
-        assertEquals(import2.getDelimEnclosing(), "#");
-        assertEquals(import2.getSchemaName(), "mySchema2");
-        assertFalse(import2.getDistinguishEmptyFromNull());
-        assertFalse(import2.getHeader());
-        assertEquals(import2.getTableName(), "myTable2");
-        assertFalse(import2.getUseHeaderNames());
-        assertEquals(import2.getDelimField(), ";");
-        assertEquals(import2.getFileName(), "/sap/ti2/demo/myData2.csv");
-        assertEquals(import2.getKeys().size(), 2);
-        assertEquals(import2.getKeys().get(0).getColumn(), "MAIN_TYPE");
-        assertEquals(import2.getKeys().get(0).getValues().size(), 1);
-        assertEquals(import2.getKeys().get(0).getValues().get(0), "BW_CO");
-        assertEquals(import2.getKeys().get(1).getColumn(), "SECOND_TYPE");
-        assertEquals(import2.getKeys().get(1).getValues().size(), 1);
-        assertEquals(import2.getKeys().get(1).getValues().get(0), "BW_PO");
+      List<Student> students = studentManager.findAll(connection, Student.class);
+      assertEquals("Changed", students.get(0).getFirstName());
+      assertEquals("Changed", students.get(0).getLastName());
+      assertEquals(25L, students.get(0).getAge().longValue());
+
+      assertEquals("Changed", students.get(1).getFirstName());
+      assertEquals("Changed", students.get(1).getLastName());
+      assertEquals(25L, students.get(1).getAge().longValue());
+
+      assertEquals("Changed", students.get(2).getFirstName());
+      assertEquals("Changed", students.get(2).getLastName());
+      assertEquals(25L, students.get(2).getAge().longValue());
+
+      writeToFile(STUDENTS_CSV_LOCATION, "");
+    }
+  }
+
+  @Test
+  public void testCleanUpDeletesEverythingRelatedToHdbtiFile()
+      throws XSKDataStructuresException, SQLException, IOException, XSKTableImportException, ProblemsException {
+    XSKTableImportConfigurationDefinition importConfigurationDefinition = new XSKTableImportConfigurationDefinition();
+    importConfigurationDefinition.setFile(CSV_FILE_LOCATION);
+    importConfigurationDefinition.setHdbtiFileName(HDBTI_LOCATION);
+    importConfigurationDefinition.setTable(STUDENTS_TABLE_NAME);
+
+    try (Connection connection = systemDatasource.getConnection()) {
+      writeToFile(STUDENTS_CSV_LOCATION, getInitialContent());
+      importArtifactManager.insert(connection, getTableImportArtifact());
+      importToCsvRelationManager.insert(connection, getXskTableImportToCsvRelation());
+      importToCsvRelationManager.insert(connection, getXskTableImportToCsvRelation());
+    }
+    try (Connection connection = datasource.getConnection()) {
+      processor.process(importConfigurationDefinition, connection);
+      xskHdbtiCoreService.cleanUpHdbtiRelatedData();
+      List<Student> students = studentManager.findAll(connection, Student.class);
+      assertEquals(0, students.size());
+    }
+    try (Connection connection = systemDatasource.getConnection()) {
+      List<XSKTableImportToCsvRelation> csvRelations = importToCsvRelationManager.findAll(connection, XSKTableImportToCsvRelation.class);
+      List<XSKTableImportArtifact> importArtifacts = importArtifactManager.findAll(connection, XSKTableImportArtifact.class);
+      List<XSKImportedCSVRecordModel> importedCSVRecordModels = importedCsvRecordsManager
+          .findAll(connection, XSKImportedCSVRecordModel.class);
+
+      assertEquals(0, csvRelations.size());
+      assertEquals(0, importArtifacts.size());
+      assertEquals(0, importedCSVRecordModels.size());
+    }
+  }
+
+  private XSKTableImportToCsvRelation getXskTableImportToCsvRelation() {
+    XSKTableImportToCsvRelation csvRelation = new XSKTableImportToCsvRelation();
+    csvRelation.setCsv(CSV_FILE_LOCATION);
+    csvRelation.setHdbti(HDBTI_LOCATION);
+    csvRelation.setCsvHash("H@sh!");
+    return csvRelation;
+  }
+
+  private XSKTableImportArtifact getTableImportArtifact() {
+    XSKTableImportArtifact xskTableImportArtifact = new XSKTableImportArtifact();
+    xskTableImportArtifact.setLocation(HDBTI_LOCATION);
+    xskTableImportArtifact.setName("DS_NAME");
+    xskTableImportArtifact.setType(IXSKTableImportModel.TYPE_HDBTI);
+    xskTableImportArtifact.setCreatedBy("TestUser");
+    xskTableImportArtifact.setHash("H@sh!");
+    xskTableImportArtifact.setCreatedAt(new Timestamp(new Date().getTime()));
+    return xskTableImportArtifact;
+  }
+
+  private void assertCorrectDataImported(List<Student> students) {
+    int importedStudentsCount = 3;
+    assertEquals(importedStudentsCount, students.size());
+    assertEquals(1L, students.get(0).getId().longValue());
+    assertEquals("Georgi", students.get(0).getFirstName());
+    assertEquals("Georgiev", students.get(0).getLastName());
+    assertEquals(27L, students.get(0).getAge().longValue());
+    assertEquals(Timestamp.valueOf("2017-09-20 14:00:12"), students.get(0).getSigned());
+
+    assertEquals(2L, students.get(1).getId().longValue());
+    assertEquals("Sara", students.get(1).getFirstName());
+    assertEquals("Toshkova", students.get(1).getLastName());
+    assertEquals(21L, students.get(1).getAge().longValue());
+    assertEquals(Timestamp.valueOf("2019-09-21 14:00:12"), students.get(1).getSigned());
+
+    assertEquals(3L, students.get(2).getId().longValue());
+    assertEquals("Toshko", students.get(2).getFirstName());
+    assertEquals("Ivanov", students.get(2).getLastName());
+    assertEquals(25L, students.get(2).getAge().longValue());
+    assertEquals(Timestamp.valueOf("2018-09-23 14:00:12"), students.get(2).getSigned());
+  }
+
+  private void assertCorrectCsvRecordMetadataImported(List<XSKImportedCSVRecordModel> importedCsvRecords) {
+    assertEquals(3, importedCsvRecords.size());
+
+    assertEquals("1", importedCsvRecords.get(0).getRowId());
+    assertEquals("STUDENTS", importedCsvRecords.get(0).getTableName());
+    assertEquals("university.students:students.csv", importedCsvRecords.get(0).getCsvLocation());
+    assertEquals(HDBTI_LOCATION, importedCsvRecords.get(0).getHdbtiLocation());
+
+    assertEquals("2", importedCsvRecords.get(1).getRowId());
+    assertEquals("STUDENTS", importedCsvRecords.get(1).getTableName());
+    assertEquals("university.students:students.csv", importedCsvRecords.get(1).getCsvLocation());
+    assertEquals(HDBTI_LOCATION, importedCsvRecords.get(1).getHdbtiLocation());
+
+    assertEquals("3", importedCsvRecords.get(2).getRowId());
+    assertEquals("STUDENTS", importedCsvRecords.get(2).getTableName());
+    assertEquals("university.students:students.csv", importedCsvRecords.get(2).getCsvLocation());
+    assertEquals(HDBTI_LOCATION, importedCsvRecords.get(2).getHdbtiLocation());
+  }
+
+  private String getInitialContent() {
+    return "1,Georgi,Georgiev,27,2017-09-20 14:00:12" + System.lineSeparator()
+        + "2,Sara,Toshkova,21,2019-09-21 14:00:12" + System.lineSeparator()
+        + "3,Toshko,Ivanov,25,2018-09-23 14:00:12" + System.lineSeparator();
+  }
+
+  private String getInitialContentWithHeaders() {
+    return "\"LAST_NAME\",\"FIRST_NAME\",\"ID\",\"AGE\",\"SIGNED\"" + System.lineSeparator()
+        + "Georgiev,Georgi,1,27,2017-09-20 14:00:12" + System.lineSeparator()
+        + "Toshkova,Sara,2,21,2019-09-21 14:00:12" + System.lineSeparator()
+        + "Ivanov,Toshko,3,25,2018-09-23 14:00:12" + System.lineSeparator();
+  }
+
+  private String getChangedContentWithHeaders() {
+    return "\"LAST_NAME\",\"FIRST_NAME\",\"ID\",\"AGE\",\"SIGNED\"" + System.lineSeparator()
+        + "Changed,Changed,1,25,2017-09-20 14:00:12" + System.lineSeparator()
+        + "Changed,Changed,2,25,2019-09-21 14:00:12" + System.lineSeparator()
+        + "Changed,Changed,3,25,2018-09-23 14:00:12" + System.lineSeparator();
+  }
+
+  private String getQuoteContent() {
+    return "1;'Georgi, \\'Junior\\'';Georgiev;27;2017-09-20 14:00:12" + System.lineSeparator();
+  }
+
+  private String getAddedContent() {
+    return "1,Georgi,Georgiev,27,2017-09-20 14:00:12" + System.lineSeparator()
+        + "2,Sara,Toshkova,21,2019-09-21 14:00:12" + System.lineSeparator()
+        + "3,Toshko,Ivanov,25,2018-09-23 14:00:12" + System.lineSeparator()
+        + "4,Pesho,Peshev,25,2014-09-23 13:10:12" + System.lineSeparator();
+  }
+
+  private String getUpdatedContent() {
+    return "1,Georgi,Georgiev,27,2017-09-20 14:00:12" + System.lineSeparator()
+        + "2,Changed,Changed,21,2018-09-21 14:00:12" + System.lineSeparator()
+        + "3,Toshko,Ivanov,25,2018-09-23 14:00:12" + System.lineSeparator();
+  }
+
+  private String getRemovedContent() {
+    return "2,Sara,Toshkova,21,2019-09-21 14:00:12" + System.lineSeparator()
+        + "3,Toshko,Ivanov,25,2018-09-23 14:00:12" + System.lineSeparator();
+  }
+
+  private void writeToFile(String path, String content) {
+    File fileToBeModified = getFileFromResource(path);
+    try {
+      assert fileToBeModified != null;
+      try (FileWriter fileWriter = new FileWriter(fileToBeModified)) {
+        fileWriter.write(content);
+      }
+    } catch (IOException e) {
+      logger.error(e.getMessage(), e);
+    }
+  }
+
+  private File getFileFromResource(String fileName) {
+
+    ClassLoader classLoader = getClass().getClassLoader();
+    URL resource = classLoader.getResource(fileName);
+    if (resource == null) {
+      throw new IllegalArgumentException("file not found! " + fileName);
+    } else {
+
+      // failed if files have whitespaces or special characters
+      //return new File(resource.getFile());
+
+      try {
+        return new File(resource.toURI());
+      } catch (URISyntaxException e) {
+        logger.error(e.getMessage(), e);
+      }
+
+      return null;
     }
 
-    @Test
-    public void testParseJSONtoHdbtiSuccessfully()
-            throws IOException, XSKArtifactParserException, XSKHDBTISyntaxErrorException, ProblemsException {
-        String hdbtiSample = org.apache.commons.io.IOUtils
-                .toString(XSKHDBTIProcessorTest.class.getResourceAsStream("/randomOrder.hdbti"), StandardCharsets.UTF_8);
+  }
 
-        List<XSKHDBTIImportConfigModel> model = processor.parseHdbtiToJSON("randomOrder.hdbti", hdbtiSample.getBytes(StandardCharsets.UTF_8));
-        String actualValue = processor.parseJSONtoHdbti((ArrayList<XSKHDBTIImportConfigModel>) model);
-        String expectedValue = "import = [\n" +
-                "{\n" +
-                "\tdelimEnclosing=\"\\\"\";\n" +
-                "\tschema = \"mySchema\";\n" +
-                "\tdistinguishEmptyFromNull = true;\n" +
-                "\theader = false;\n" +
-                "\ttable = \"myTable\";\n" +
-                "\tuseHeaderNames = false;\n" +
-                "\tdelimField = \";\";\n" +
-                "\tkeys = [\"GROUP_TYPE\":\"BW_CUBE\",\"GROUP_TYPE\":\"BW_DSO\",\"GROUP_TYPE\":\"BW_PSA\"];\n" +
-                "\tfile = \"sap.ti2.demo:myData.csv\";\n" +
-                "}, \n" +
-                "{\n" +
-                "\tdelimEnclosing=\"#\";\n" +
-                "\tschema = \"mySchema2\";\n" +
-                "\tdistinguishEmptyFromNull = false;\n" +
-                "\theader = false;\n" +
-                "\ttable = \"myTable2\";\n" +
-                "\tuseHeaderNames = false;\n" +
-                "\tdelimField = \";\";\n" +
-                "\tkeys = [\"MAIN_TYPE\":\"BW_CO\", \"SECOND_TYPE\":\"BW_PO\"];\n" +
-                "\tfile = \"sap.ti2.demo:myData2.csv\";\n" +
-                "}];";
+  @Test
+  public void testParseHdbtiToJSONSuccessfully()
+      throws IOException, XSKArtifactParserException, XSKHDBTISyntaxErrorException, ProblemsException {
+    String hdbtiSample = org.apache.commons.io.IOUtils
+        .toString(XSKHDBTIProcessorTest.class.getResourceAsStream("/randomOrder.hdbti"), StandardCharsets.UTF_8);
 
-        assertEquals(expectedValue, actualValue);
-    }
+    List<XSKHDBTIImportConfigModel> model = processor.parseHdbtiToJSON("randomOrder.hdbti", hdbtiSample.getBytes(StandardCharsets.UTF_8));
+    assertEquals(model.size(), 2);
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseJSONtoHdbtiFailWithIncorrectFilePath() {
-        XSKHDBTIImportConfigModel model = new XSKHDBTIImportConfigModel();
-        model.setDelimEnclosing("'");
-        model.setSchemaName("schema");
-        model.setHeader(true);
-        model.setTableName("table");
-        model.setFileName("workspace:csv=file-Name_cAN|be+running (งツ)ว");
+    XSKHDBTIImportConfigModel import1 = model.get(0);
+    assertEquals(import1.getDelimEnclosing(), "\"");
+    assertEquals(import1.getSchemaName(), "mySchema");
+    assertTrue(import1.getDistinguishEmptyFromNull());
+    assertFalse(import1.getHeader());
+    assertEquals(import1.getTableName(), "myTable");
+    assertFalse(import1.getUseHeaderNames());
+    assertEquals(import1.getDelimField(), ";");
+    assertEquals(import1.getFileName(), "/sap/ti2/demo/myData.csv");
+    assertEquals(import1.getKeys().size(), 1);
+    assertEquals(import1.getKeys().get(0).getColumn(), "GROUP_TYPE");
+    assertEquals(import1.getKeys().get(0).getValues().size(), 3);
+    assertEquals(import1.getKeys().get(0).getValues().get(0), "BW_CUBE");
+    assertEquals(import1.getKeys().get(0).getValues().get(1), "BW_DSO");
+    assertEquals(import1.getKeys().get(0).getValues().get(2), "BW_PSA");
 
-        List<XSKHDBTIImportConfigModel> list = new ArrayList<>(Arrays.asList(model));
-        processor.parseJSONtoHdbti((ArrayList<XSKHDBTIImportConfigModel>) list);
-    }
+    XSKHDBTIImportConfigModel import2 = model.get(1);
+    assertEquals(import2.getDelimEnclosing(), "#");
+    assertEquals(import2.getSchemaName(), "mySchema2");
+    assertFalse(import2.getDistinguishEmptyFromNull());
+    assertFalse(import2.getHeader());
+    assertEquals(import2.getTableName(), "myTable2");
+    assertFalse(import2.getUseHeaderNames());
+    assertEquals(import2.getDelimField(), ";");
+    assertEquals(import2.getFileName(), "/sap/ti2/demo/myData2.csv");
+    assertEquals(import2.getKeys().size(), 2);
+    assertEquals(import2.getKeys().get(0).getColumn(), "MAIN_TYPE");
+    assertEquals(import2.getKeys().get(0).getValues().size(), 1);
+    assertEquals(import2.getKeys().get(0).getValues().get(0), "BW_CO");
+    assertEquals(import2.getKeys().get(1).getColumn(), "SECOND_TYPE");
+    assertEquals(import2.getKeys().get(1).getValues().size(), 1);
+    assertEquals(import2.getKeys().get(1).getValues().get(0), "BW_PO");
+  }
 
-    @Test
-    public void testParseJSONtoHdbtiSuccessfullyWithFileNameWithoutPath() {
-        XSKHDBTIImportConfigModel model = new XSKHDBTIImportConfigModel();
-        model.setDelimEnclosing("'");
-        model.setSchemaName("schema");
-        model.setHeader(true);
-        model.setTableName("table");
-        model.setFileName("myData2.csv");
+  @Test
+  public void testParseJSONtoHdbtiSuccessfully()
+      throws IOException, XSKArtifactParserException, XSKHDBTISyntaxErrorException, ProblemsException {
+    String hdbtiSample = org.apache.commons.io.IOUtils
+        .toString(XSKHDBTIProcessorTest.class.getResourceAsStream("/randomOrder.hdbti"), StandardCharsets.UTF_8);
 
-        String expectedValue = "import = [\n" +
-                "{\n" +
-                "\tdelimEnclosing=\"'\";\n" +
-                "\tschema = \"schema\";\n" +
-                "\theader = true;\n" +
-                "\ttable = \"table\";\n" +
-                "\tfile = \"myData2.csv\";\n" +
-                "}];";
+    List<XSKHDBTIImportConfigModel> model = processor.parseHdbtiToJSON("randomOrder.hdbti", hdbtiSample.getBytes(StandardCharsets.UTF_8));
+    String actualValue = processor.parseJSONtoHdbti((ArrayList<XSKHDBTIImportConfigModel>) model);
+    String expectedValue = "import = [\n" +
+        "{\n" +
+        "\tdelimEnclosing=\"\\\"\";\n" +
+        "\tschema = \"mySchema\";\n" +
+        "\tdistinguishEmptyFromNull = true;\n" +
+        "\theader = false;\n" +
+        "\ttable = \"myTable\";\n" +
+        "\tuseHeaderNames = false;\n" +
+        "\tdelimField = \";\";\n" +
+        "\tkeys = [\"GROUP_TYPE\":\"BW_CUBE\",\"GROUP_TYPE\":\"BW_DSO\",\"GROUP_TYPE\":\"BW_PSA\"];\n" +
+        "\tfile = \"sap.ti2.demo:myData.csv\";\n" +
+        "}, \n" +
+        "{\n" +
+        "\tdelimEnclosing=\"#\";\n" +
+        "\tschema = \"mySchema2\";\n" +
+        "\tdistinguishEmptyFromNull = false;\n" +
+        "\theader = false;\n" +
+        "\ttable = \"myTable2\";\n" +
+        "\tuseHeaderNames = false;\n" +
+        "\tdelimField = \";\";\n" +
+        "\tkeys = [\"MAIN_TYPE\":\"BW_CO\", \"SECOND_TYPE\":\"BW_PO\"];\n" +
+        "\tfile = \"sap.ti2.demo:myData2.csv\";\n" +
+        "}];";
 
-        String actualResult =  processor.parseJSONtoHdbti(new ArrayList<>(Arrays.asList(model)));
-        assertEquals(expectedValue, actualResult);
-    }
+    assertEquals(expectedValue, actualValue);
+  }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseJSONtoHdbtiFailWithIncorrectSchemaName() {
-        XSKHDBTIImportConfigModel model = new XSKHDBTIImportConfigModel();
-        model.setDelimEnclosing("'");
-        model.setSchemaName("schema-Name_cAN|be\\whatever ¯\\_(ツ)_/¯");
-        model.setHeader(true);
-        model.setTableName("table");
-        model.setFileName("myData2.csv");
+  @Test(expected = IllegalArgumentException.class)
+  public void testParseJSONtoHdbtiFailWithIncorrectFilePath() {
+    XSKHDBTIImportConfigModel model = new XSKHDBTIImportConfigModel();
+    model.setDelimEnclosing("'");
+    model.setSchemaName("schema");
+    model.setHeader(true);
+    model.setTableName("table");
+    model.setFileName("workspace:csv=file-Name_cAN|be+running (งツ)ว");
 
-        processor.parseJSONtoHdbti(new ArrayList<>(Arrays.asList(model)));
-    }
+    List<XSKHDBTIImportConfigModel> list = new ArrayList<>(Arrays.asList(model));
+    processor.parseJSONtoHdbti((ArrayList<XSKHDBTIImportConfigModel>) list);
+  }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseJSONtoHdbtiFailWithIncorrectTableName() {
-        XSKHDBTIImportConfigModel model = new XSKHDBTIImportConfigModel();
-        model.setDelimEnclosing("'");
-        model.setSchemaName("schema");
-        model.setHeader(true);
-        model.setTableName("table-Name_cAN|be@bear ʕ•ᴥ•ʔ");
-        model.setFileName("myData2.csv");
+  @Test
+  public void testParseJSONtoHdbtiSuccessfullyWithFileNameWithoutPath() {
+    XSKHDBTIImportConfigModel model = new XSKHDBTIImportConfigModel();
+    model.setDelimEnclosing("'");
+    model.setSchemaName("schema");
+    model.setHeader(true);
+    model.setTableName("table");
+    model.setFileName("myData2.csv");
 
-        processor.parseJSONtoHdbti(new ArrayList<>(Arrays.asList(model)));
-    }
+    String expectedValue = "import = [\n" +
+        "{\n" +
+        "\tdelimEnclosing=\"'\";\n" +
+        "\tschema = \"schema\";\n" +
+        "\theader = true;\n" +
+        "\ttable = \"table\";\n" +
+        "\tfile = \"myData2.csv\";\n" +
+        "}];";
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testParseJSONtoHdbtiFailWithIncorrectKeyColumn() {
-        XSKHDBTIImportConfigModel model = new XSKHDBTIImportConfigModel();
-        model.setDelimEnclosing("'");
-        model.setSchemaName("schema");
-        model.setHeader(true);
-        model.setTableName("table");
-        model.setFileName("myData2.csv");
-        XSKHDBTIImportConfigModel.Pair pair = new XSKHDBTIImportConfigModel.Pair("%something&\":\"ƪ(ړײ)ƪ\u200B\u200B", new ArrayList<>((Collections.singletonList("BW_CUBE"))));
-        model.getKeys().add(pair);
+    String actualResult = processor.parseJSONtoHdbti(new ArrayList<>(Arrays.asList(model)));
+    assertEquals(expectedValue, actualResult);
+  }
 
-        processor.parseJSONtoHdbti(new ArrayList<>(Arrays.asList(model)));
-    }
+  @Test(expected = IllegalArgumentException.class)
+  public void testParseJSONtoHdbtiFailWithIncorrectSchemaName() {
+    XSKHDBTIImportConfigModel model = new XSKHDBTIImportConfigModel();
+    model.setDelimEnclosing("'");
+    model.setSchemaName("schema-Name_cAN|be\\whatever ¯\\_(ツ)_/¯");
+    model.setHeader(true);
+    model.setTableName("table");
+    model.setFileName("myData2.csv");
+
+    processor.parseJSONtoHdbti(new ArrayList<>(Arrays.asList(model)));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParseJSONtoHdbtiFailWithIncorrectTableName() {
+    XSKHDBTIImportConfigModel model = new XSKHDBTIImportConfigModel();
+    model.setDelimEnclosing("'");
+    model.setSchemaName("schema");
+    model.setHeader(true);
+    model.setTableName("table-Name_cAN|be@bear ʕ•ᴥ•ʔ");
+    model.setFileName("myData2.csv");
+
+    processor.parseJSONtoHdbti(new ArrayList<>(Arrays.asList(model)));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParseJSONtoHdbtiFailWithIncorrectKeyColumn() {
+    XSKHDBTIImportConfigModel model = new XSKHDBTIImportConfigModel();
+    model.setDelimEnclosing("'");
+    model.setSchemaName("schema");
+    model.setHeader(true);
+    model.setTableName("table");
+    model.setFileName("myData2.csv");
+    XSKHDBTIImportConfigModel.Pair pair = new XSKHDBTIImportConfigModel.Pair("%something&\":\"ƪ(ړײ)ƪ\u200B\u200B",
+        new ArrayList<>((Collections.singletonList("BW_CUBE"))));
+    model.getKeys().add(pair);
+
+    processor.parseJSONtoHdbti(new ArrayList<>(Arrays.asList(model)));
+  }
 }

--- a/modules/engines/engine-hdbti/src/test/java/com/sap/xsk/hdbti/repository/TestRepository.java
+++ b/modules/engines/engine-hdbti/src/test/java/com/sap/xsk/hdbti/repository/TestRepository.java
@@ -14,9 +14,15 @@ package com.sap.xsk.hdbti.repository;
 import java.io.IOException;
 import org.eclipse.dirigible.repository.api.IResource;
 import org.eclipse.dirigible.repository.api.RepositoryReadException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestRepository extends AbstractTestRepository {
-    @Override
+
+  private static final Logger logger = LoggerFactory.getLogger(TestRepository.class);
+
+
+  @Override
     public IResource getResource(String s) {
         try {
             byte[] content = TestRepository.class.getResourceAsStream(s).readAllBytes();
@@ -24,7 +30,7 @@ public class TestRepository extends AbstractTestRepository {
             resource.setContent(content);
             return resource;
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
         }
 
         return null;

--- a/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/hdi/synchronizer/XSKDataStructuresHDISynchronizer.java
+++ b/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/hdi/synchronizer/XSKDataStructuresHDISynchronizer.java
@@ -379,7 +379,7 @@ public class XSKDataStructuresHDISynchronizer extends AbstractSynchronizer {
       try {
         this.xskhdiContainerCreateProcessor.execute(connection, hdiModel);
       } catch (ProblemsException e) {
-        e.printStackTrace();
+        logger.error(e.getMessage(), e);
       }
     });
   }

--- a/modules/parsers/parser-calculationview/pom.xml
+++ b/modules/parsers/parser-calculationview/pom.xml
@@ -57,6 +57,11 @@
       <version>2.7</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.sap.xsk</groupId>
+      <artifactId>xsk-modules-engines-commons</artifactId>
+      <version>0.9.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/modules/parsers/parser-calculationview/src/test/java/com/sap/xsk/models/hdbcalculationview/tests/CalculationViewTest.java
+++ b/modules/parsers/parser-calculationview/src/test/java/com/sap/xsk/models/hdbcalculationview/tests/CalculationViewTest.java
@@ -26,7 +26,12 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import org.junit.Test;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class CalculationViewTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(CalculationViewTest.class);
 
   @Test
   public void serialize() throws JAXBException {
@@ -57,7 +62,7 @@ public class CalculationViewTest {
       xml = org.apache.commons.io.IOUtils.toString(CalculationViewTest.class.getResourceAsStream("/test.calculationview"));
     } catch (IOException e) {
       fail("Parsing of calculation view failed.");
-      e.printStackTrace();
+      logger.error(e.getMessage(), e);
     }
 
     xml = xml.replace("<Calculation:scenario", "<CalculationScenario");

--- a/modules/parsers/parser-hdbcalculationview/pom.xml
+++ b/modules/parsers/parser-hdbcalculationview/pom.xml
@@ -1,66 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>com.sap.xsk</groupId>
-		<artifactId>xsk-modules-parsers-parent</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
-		<relativePath>../pom.xml</relativePath>
-	</parent>
+  <parent>
+    <groupId>com.sap.xsk</groupId>
+    <artifactId>xsk-modules-parsers-parent</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
-	<name>XSK - Modules - Parsers - HDB Calculation View</name>
-	<artifactId>xsk-modules-parsers-hdbcalculationview</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
+  <name>XSK - Modules - Parsers - HDB Calculation View</name>
+  <artifactId>xsk-modules-parsers-hdbcalculationview</artifactId>
+  <version>0.9.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
 
-	<dependencies>
-		<dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.2.9</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.2.5-b10</version>
-        </dependency>
-		<dependency>
-		    <groupId>com.sun.activation</groupId>
-		    <artifactId>javax.activation</artifactId>
-		    <version>1.2.0</version>
-		</dependency>
-		
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>${hamcrest.all.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-		    <groupId>commons-io</groupId>
-		    <artifactId>commons-io</artifactId>
-		    <version>2.7</version>
-		    <scope>test</scope>
-		</dependency>
-	</dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.2.5-b10</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <version>1.2.0</version>
+    </dependency>
 
-    <properties>
-		<license.header.location>../../../licensing-header.txt</license.header.location>
-	</properties>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.all.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sap.xsk</groupId>
+      <artifactId>xsk-modules-engines-commons</artifactId>
+      <version>0.9.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <license.header.location>../../../licensing-header.txt</license.header.location>
+  </properties>
 
 </project>

--- a/modules/parsers/parser-hdbcalculationview/src/test/java/com/sap/xsk/models/hdbcalculationview/tests/HDBCalculationViewTest.java
+++ b/modules/parsers/parser-hdbcalculationview/src/test/java/com/sap/xsk/models/hdbcalculationview/tests/HDBCalculationViewTest.java
@@ -27,7 +27,12 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import org.junit.Test;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class HDBCalculationViewTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(HDBCalculationViewTest.class);
 
   @Test
   public void serialize() throws JAXBException {
@@ -59,7 +64,7 @@ public class HDBCalculationViewTest {
       xml = org.apache.commons.io.IOUtils.toString(HDBCalculationViewTest.class.getResourceAsStream("/test.hdbcalculationview"));
     } catch (IOException e) {
       fail("Parsing of calculation view failed.");
-      e.printStackTrace();
+      logger.error(e.getMessage(), e);
     }
 
     xml = xml.replace("<Calculation:scenario", "<Calculation:calculationScenario");


### PR DESCRIPTION
Resolves #539 

Replaced `printStackTrace` with `logger` for exceptions.