### PR TITLE
fix: temporarily use the old dirigible require function

### DIFF
--- a/modules/engines/engine-xsjs/src/main/java/com/sap/xsk/engine/XSKJavascriptEngineExecutor.java
+++ b/modules/engines/engine-xsjs/src/main/java/com/sap/xsk/engine/XSKJavascriptEngineExecutor.java
@@ -14,7 +14,9 @@ package com.sap.xsk.engine;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.util.Map;
 import org.apache.commons.io.IOUtils;
+import org.eclipse.dirigible.commons.api.scripting.ScriptingException;
 import org.eclipse.dirigible.engine.api.script.IScriptEngineExecutor;
 import org.eclipse.dirigible.engine.js.api.IJavascriptModuleSourceProvider;
 import org.eclipse.dirigible.engine.js.graalvm.processor.GraalVMJavascriptEngineExecutor;
@@ -54,6 +56,32 @@ public class XSKJavascriptEngineExecutor extends GraalVMJavascriptEngineExecutor
       XSK_API_CONTENT = IOUtils.toString(XSKJavascriptEngineExecutor.class.getResourceAsStream("/META-INF/dirigible" + XSK_API_LOCATION), DEFAULT_CHARSET);
     }
     return XSK_API_CONTENT;
+  }
+
+  @Override
+  public Object executeServiceModule(String module, Map<Object, Object> executionContext) throws ScriptingException {
+    return super.executeServiceModule(module, executionContext);
+  }
+
+  @Override
+  public Object executeServiceCode(String code, Map<Object, Object> executionContext) throws ScriptingException {
+    return super.executeServiceCode(code, executionContext);
+  }
+
+  @Override
+  public Object evalCode(String code, Map<Object, Object> executionContext) throws ScriptingException {
+    return super.evalCode(code, executionContext);
+  }
+
+  @Override
+  public Object evalModule(String module, Map<Object, Object> executionContext) throws ScriptingException {
+    return super.evalModule(module, executionContext);
+  }
+
+  @Override
+  public Object executeService(String moduleOrCode, Map<Object, Object> executionContext, boolean isModule, boolean commonJSModule)
+      throws ScriptingException {
+    return super.executeService(moduleOrCode, executionContext, isModule, false);
   }
 
   // TODO: Handle XSK Job calls -> callXSKJobFunction(...)


### PR DESCRIPTION
Currently, because in the `beforeEval` function we evaluate JS code having require statements, an exception is thrown:
`ReferenceError: "require" is not defined
	at <js> :program(Unnamed:18:512-518)
	at org.graalvm.polyglot.Context.eval(Context.java:373)
	at com.sap.xsk.engine.XSKJavascriptEngineExecutor.beforeEval(XSKJavascriptEngineExecutor.java:43)`

Because of the new require function implemented in the Dirigible, we cannot just simply eval JS code that has a require. This PR makes the XSK use the old require functionality but it's just a temporarily fix. We should either improve the Dirigible JS executor to handle context evals in a better way OR change the beforeEval method to not give access to the Graal context OR make the XSK JS service eval code in a similar way as how it's done in the base Dirigible JS executor. We should discuss what approach to implement.