### PR TITLE
chore: update selenium tests with hdi changes

### DIFF
--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
@@ -177,14 +177,14 @@ public class MigrationITest {
 
     // Open all files by double-click
     var jstreeAnchors = new ArrayList<WebElement>();
-    jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_14_anchor"))));
-    jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_11_anchor"))));
     jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_7_anchor"))));
     jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_8_anchor"))));
     jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_9_anchor"))));
-    jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_13_anchor"))));
+    jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_11_anchor"))));
     jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_12_anchor"))));
-    jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_10_anchor"))));
+    jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_13_anchor"))));
+    jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_14_anchor"))));
+    jstreeAnchors.add(browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.id("j1_16_anchor"))));
 
     for (var anchor : jstreeAnchors) {
       browserActions.doubleClick(anchor).perform();


### PR DESCRIPTION
New files `xsk-test-app.hdi` `xsk-test-app.hdiconfig` were added to the test project, which used to validate the migration. That changed the id's in the tree structure and the selenium tests could not double click on the files to open them for validation. 