### PR TITLE
feat: add logging of visible html and screenshots to the selenium test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,12 +1,8 @@
 name: Nightly Build
 
-#on:
-#  schedule:
-#    - cron: "0 22 * * *"
-
 on:
-  push:
-    branches: [ yakov/migration-selenium-update ]
+  schedule:
+    - cron: "0 22 * * *"
 
 jobs:
   integration-tests:
@@ -75,14 +71,15 @@ jobs:
           ITESTS_SELENIUM_HANA_DB_SCHEMA_2: ${{ secrets.ITESTS_SELENIUM_HANA_DB_SCHEMA_2 }}
           ITESTS_SELENIUM_HANA_DB_USERNAME: ${{ secrets.ITESTS_SELENIUM_HANA_DB_USERNAME }}
           ITESTS_SELENIUM_HANA_DB_PASSWORD: ${{ secrets.ITESTS_SELENIUM_HANA_DB_PASSWORD }}
+          ITESTS_SELENIUM_ARTIFACT_PASSWORD: ${{ secrets.ITESTS_SELENIUM_ARTIFACT_PASSWORD }}
 
       # Upload Selenium Logs to a GitHub artifact
       - name: Save Selenium Logs
         uses: actions/upload-artifact@v2
         with:
           name: selenium-test-logs-upload
-          path: /home/runner/work/xsk/xsk/integration-tests/ui/SeleniumOut
-          retention-days: 5
+          path: /home/runner/work/xsk/xsk/integration-tests/ui/SeleniumOut.zip
+          retention-days: 2
         if: always()
 
       - name: Slack Notification

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,12 @@
 name: Nightly Build
 
+#on:
+#  schedule:
+#    - cron: "0 22 * * *"
+
 on:
-  schedule:
-    - cron: "0 22 * * *"
+  push:
+    branches: [ yakov/migration-selenium-update ]
 
 jobs:
   integration-tests:
@@ -72,13 +76,13 @@ jobs:
           ITESTS_SELENIUM_HANA_DB_USERNAME: ${{ secrets.ITESTS_SELENIUM_HANA_DB_USERNAME }}
           ITESTS_SELENIUM_HANA_DB_PASSWORD: ${{ secrets.ITESTS_SELENIUM_HANA_DB_PASSWORD }}
 
-      # Upload screenshots to a GitHub artifact
-      - name: Save screenshots
+      # Upload Selenium Logs to a GitHub artifact
+      - name: Save Selenium Logs
         uses: actions/upload-artifact@v2
         with:
-          name: selenium-test-screenshots
-          path: /home/runner/work/xsk/xsk/*.jpg
-          retention-days: 2
+          name: selenium-test-logs-upload
+          path: /home/runner/work/xsk/xsk/integration-tests/ui/SeleniumOut
+          retention-days: 5
         if: always()
 
       - name: Slack Notification

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -16,8 +16,8 @@
 	<packaging>pom</packaging>
 
 	<modules>
-<!--		<module>engine-hdb</module>-->
-<!--		<module>engine-xsodata</module>-->
+		<module>engine-hdb</module>
+		<module>engine-xsodata</module>
 		<module>ui</module>
   </modules>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -16,8 +16,8 @@
 	<packaging>pom</packaging>
 
 	<modules>
-		<module>engine-hdb</module>
-		<module>engine-xsodata</module>
+<!--		<module>engine-hdb</module>-->
+<!--		<module>engine-xsodata</module>-->
 		<module>ui</module>
   </modules>
 

--- a/integration-tests/ui/pom.xml
+++ b/integration-tests/ui/pom.xml
@@ -30,6 +30,13 @@
         </dependency>
 
         <dependency>
+          <groupId>net.lingala.zip4j</groupId>
+          <artifactId>zip4j</artifactId>
+          <version>${zip4j.version}</version>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>

--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationCredentials.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationCredentials.java
@@ -66,4 +66,11 @@ class MigrationCredentials {
   public String getHanaPassword() {
     return hanaPassword;
   }
+
+  public String removePasswordsFromString(String input) {
+    input = input.replaceAll(getHanaPassword(), "HIDDEN_PASSWORD");
+    input = input.replaceAll(getPassword(), "HIDDEN_PASSWORD");
+    return input;
+  }
+
 }

--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
@@ -51,7 +51,7 @@ public class MigrationITest {
   private JavascriptExecutor jsExecutor;
 
   private MigrationCredentials credentials;
-  private MigrationValidation validation;
+  private final MigrationValidation validation;
   private SeleniumLogger debug;
 
   private final String host = "127.0.0.1";
@@ -69,21 +69,29 @@ public class MigrationITest {
   public void migrationTest(String param) throws InterruptedException, IOException {
     credentials = new MigrationCredentials(param.contains("Hana2"));
     setupBrowser(param);
-    debug = new SeleniumLogger(browser, param);
-    navigateToMigrationPerspective();
-    debug.save();
-    enterNeoDBTunnelCredentials();
-    debug.save();
-    enterHanaCredentials();
-    debug.save();
-    selectDeliveryUnits();
-    debug.save();
-    goToWorkspace();
-    debug.save();
-    openFilesFromJstree();
-    debug.save();
-    validateAllMigratedFileContents();
-    debug.save();
+    debug = new SeleniumLogger(browser, credentials, param);
+
+    try {
+      navigateToMigrationPerspective();
+      debug.save();
+      enterNeoDBTunnelCredentials();
+      debug.save();
+      enterHanaCredentials();
+      debug.save();
+      selectDeliveryUnits();
+      debug.save();
+      goToWorkspace();
+      debug.save();
+      openFilesFromJstree();
+      debug.save();
+      validateAllMigratedFileContents();
+      debug.save();
+      debug.finish();
+    } catch(Throwable exception) {
+      debug.save();
+      debug.finish();
+      throw exception;
+    }
   }
 
   private void setupBrowser(String param) {
@@ -177,7 +185,8 @@ public class MigrationITest {
 
   private void goToWorkspace() throws IOException {
     browserWait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//*[@ng-click=\"goToWorkspace()\"]"))).click();
-    debug.save();
+    browserWait.until(ExpectedConditions.titleIs("Workspace | XSK WebIDE"));
+    browser.switchTo().defaultContent();
   }
 
   private void openFilesFromJstree() throws InterruptedException, IOException {

--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationValidation.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationValidation.java
@@ -15,9 +15,28 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 class MigrationValidation {
+
+  public static final Path INDEX = Paths.get("src/test/resources/migration/testProject/index.html");
+  public static final Path INDEXUI5 = Paths.get("src/test/resources/migration/testProject/indexUI5.html");
+  public static final Path XSACCESS = Paths.get("src/test/resources/migration/testProject/.xsaccess");
+  public static final Path XSAPP = Paths.get("src/test/resources/migration/testProject/.xsapp");
+  public static final Path LOGIC = Paths.get("src/test/resources/migration/testProject/logic.xsjs");
+  public static final Path CONTACT_REGULAR = Paths.get("src/test/resources/migration/testProject/images/Contact_regular.png");
+  public static final Path CONTACT_HOVER = Paths.get("src/test/resources/migration/testProject/images/Contact_hover.png");
+  public static final Path SAPLOGO = Paths.get("src/test/resources/migration/testProject/images/SAPLogo.gif");
+
+  public static final String XPATH_COMMON = "//iframe[@src=\"../ide-monaco/editor.html?file=/workspace/xsk-test-app/";
+  public static final String XPATH_INDEX = "index.html&contentType=text/html\"]";
+  public static final String XPATH_INDEXUI5 = "indexUI5.html&contentType=text/html\"]";
+  public static final String XPATH_XSACCESS = ".xsaccess&contentType=text/plain\"]";
+  public static final String XPATH_XSAPP = ".xsapp&contentType=text/plain\"]";
+  public static final String XPATH_LOGIC = "logic.xsjs&contentType=application/javascript\"]";
+
+  public static final String IMAGE_URL_COMMON = "http://127.0.0.1:8080/services/v4/ide/workspaces/workspace/xsk-test-app/images/";
 
   private final String index;
   private final String indexUI5;
@@ -29,14 +48,14 @@ class MigrationValidation {
   private final BufferedImage sapLogo;
 
   MigrationValidation() throws IOException {
-    index = Files.readString(Paths.get("src/test/resources/migration/testProject/index.html"));
-    indexUI5 = Files.readString(Paths.get("src/test/resources/migration/testProject/indexUI5.html"));
-    xsaccess = Files.readString(Paths.get("src/test/resources/migration/testProject/.xsaccess"));
-    xsapp = Files.readString(Paths.get("src/test/resources/migration/testProject/.xsapp"));
-    logic = Files.readString(Paths.get("src/test/resources/migration/testProject/logic.xsjs"));
-    contactRegular = ImageIO.read(Paths.get("src/test/resources/migration/testProject/images/Contact_regular.png").toFile());
-    contactHover = ImageIO.read(Paths.get("src/test/resources/migration/testProject/images/Contact_hover.png").toFile());
-    sapLogo = ImageIO.read(Paths.get("src/test/resources/migration/testProject/images/SAPLogo.gif").toFile());
+    index = Files.readString(INDEX);
+    indexUI5 = Files.readString(INDEXUI5);
+    xsaccess = Files.readString(XSACCESS);
+    xsapp = Files.readString(XSAPP);
+    logic = Files.readString(LOGIC);
+    contactRegular = ImageIO.read(CONTACT_REGULAR.toFile());
+    contactHover = ImageIO.read(CONTACT_HOVER.toFile());
+    sapLogo = ImageIO.read(SAPLOGO.toFile());
   }
 
   String getIndex() {
@@ -70,4 +89,5 @@ class MigrationValidation {
   BufferedImage getSapLogo() {
     return sapLogo;
   }
+
 }

--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/SeleniumLogger.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/SeleniumLogger.java
@@ -1,0 +1,48 @@
+package com.xsk.integration.tests.migration;
+
+import org.apache.commons.io.FileUtils;
+import org.openqa.selenium.By;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class SeleniumLogger {
+  private static final String PREFIX = "SeleniumOut";
+  private static final String SEPARATOR = "-";
+  private int screenshotID = 0;
+  private int pageSourceID = 0;
+  private WebDriver browser;
+  private String testName;
+
+  public SeleniumLogger(WebDriver browser, String testName) {
+    this.browser = browser;
+    this.testName = testName;
+  }
+
+  void saveScreenshot() throws IOException {
+    TakesScreenshot scrShot =((TakesScreenshot)browser);
+    File SrcFile=scrShot.getScreenshotAs(OutputType.FILE);
+    String fileName = PREFIX + "/" + PREFIX + SEPARATOR + testName + SEPARATOR + screenshotID + ".jpg";
+    File DestFile=new File(fileName);
+    System.out.println("[SeleniumOut - Saved Page Screenshot]: " + DestFile.getAbsolutePath());
+    FileUtils.copyFile(SrcFile, DestFile);
+    screenshotID++;
+  }
+
+  void savePageHtml() throws IOException {
+    var source = browser.getPageSource();
+    String fileName = PREFIX + "/" + PREFIX + SEPARATOR + testName + SEPARATOR + pageSourceID + ".html";
+    File file = new File(fileName);
+    FileUtils.write(file, source, StandardCharsets.UTF_8);
+    System.out.println("[SeleniumOut - Saved Page HTML]: " + file.getAbsolutePath());
+    pageSourceID++;
+  }
+
+  void save() throws IOException {
+    saveScreenshot();
+    savePageHtml();
+  }
+}

--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/SeleniumLogger.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/SeleniumLogger.java
@@ -1,7 +1,12 @@
 package com.xsk.integration.tests.migration;
 
+import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.ZipParameters;
+import net.lingala.zip4j.model.enums.AesKeyStrength;
+import net.lingala.zip4j.model.enums.EncryptionMethod;
 import org.apache.commons.io.FileUtils;
-import org.openqa.selenium.By;
+import org.eclipse.dirigible.commons.config.Configuration;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
@@ -14,12 +19,16 @@ public class SeleniumLogger {
   private static final String SEPARATOR = "-";
   private int screenshotID = 0;
   private int pageSourceID = 0;
-  private WebDriver browser;
-  private String testName;
+  private final WebDriver browser;
+  private final MigrationCredentials credentials;
+  private final String testName;
+  private final String zipPassword;
 
-  public SeleniumLogger(WebDriver browser, String testName) {
+  public SeleniumLogger(WebDriver browser, MigrationCredentials credentials, String testName) {
     this.browser = browser;
+    this.credentials = credentials;
     this.testName = testName;
+    this.zipPassword = Configuration.get("ITESTS_SELENIUM_ARTIFACT_PASSWORD");
   }
 
   void saveScreenshot() throws IOException {
@@ -34,6 +43,7 @@ public class SeleniumLogger {
 
   void savePageHtml() throws IOException {
     var source = browser.getPageSource();
+    source = credentials.removePasswordsFromString(source);
     String fileName = PREFIX + "/" + PREFIX + SEPARATOR + testName + SEPARATOR + pageSourceID + ".html";
     File file = new File(fileName);
     FileUtils.write(file, source, StandardCharsets.UTF_8);
@@ -42,7 +52,22 @@ public class SeleniumLogger {
   }
 
   void save() throws IOException {
-    saveScreenshot();
-    savePageHtml();
+    try {
+      saveScreenshot();
+      savePageHtml();
+    } catch (Throwable exception) {
+      System.out.println("[SeleniumOut - Warning]: Could not save snapshot for some reason.");
+      throw exception;
+    }
+  }
+
+  void finish() throws ZipException {
+    ZipParameters zipParameters = new ZipParameters();
+    zipParameters.setEncryptFiles(true);
+    zipParameters.setEncryptionMethod(EncryptionMethod.AES);
+    zipParameters.setAesKeyStrength(AesKeyStrength.KEY_STRENGTH_256);
+    ZipFile zipFile = new ZipFile("SeleniumOut.zip", zipPassword.toCharArray());
+    zipFile.addFolder(new File("./SeleniumOut"), zipParameters);
+    System.out.println("[SeleniumOut - Zipped all output to: " + zipFile.getFile().getAbsolutePath());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,7 @@
 		<lucene.version>7.0.1</lucene.version>
 		<chemistry.version>1.1.0</chemistry.version>
 		<flowable.version>6.3.0</flowable.version>
+    <zip4j.version>2.9.0</zip4j.version>
 		<jaxb.version>2.3.0</jaxb.version>
 		<jaxws.version>2.3.0</jaxws.version>
 		<emf.mwe.utils.version>1.4.0</emf.mwe.utils.version>


### PR DESCRIPTION
* This PR fixes the current issue with the selenium test failing, due to not being able to validate logic.xsjs. The issue was caused by searching migrated files in jstree via their DOM id (not their file name/DOM content), when trying to open them for validation.

* New Feture: Web Browser Snapshots (containing visible page html and screenshots) are taken and uploaded to a github artifact that is retained 2 days with a size of ~10mb. This data can be useful to examine the cause for a future failed nightly selenium test.
The data format is a password protected `.zip` file and it can contain all the data entered during a migration including names, emails, password lenght (visible in the images), but not password value (not visible in the image and html). 

* :warning: Before merge of this PR add a github secret named `ITESTS_SELENIUM_ARTIFACT_PASSWORD` that contains the resulting artifact's zip password. Please consider the test account accesss due to the possibility of exposing credentials. 


