### PR TITLE
Clone issue only on added label

### DIFF
--- a/.github/workflows/shadow-label.yml
+++ b/.github/workflows/shadow-label.yml
@@ -4,6 +4,7 @@ on:
         types: [labeled]
 jobs:
     copy:
+        if: github.event.label.name == 'shadow'
         runs-on: ubuntu-latest
         steps:
             - uses: dpanayotov/issue-cloner@v0.3


### PR DESCRIPTION
Currently, there's a problem that when an issue is labeled with a label and the `shadow` label is already in the labels, the issue will be cloned again. This fixes it by checking that the event is for adding this specific label