### PR TITLE
Uploading xsodata artifacts in workspace fix

### DIFF
--- a/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/ds/filter/WrappedHttpServletRequest.java
+++ b/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/ds/filter/WrappedHttpServletRequest.java
@@ -1,0 +1,41 @@
+package com.sap.xsk.xsodata.ds.filter;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+final class WrappedHttpServletRequest extends HttpServletRequestWrapper {
+
+  private final Map<String, String> customHeaders;
+
+  public WrappedHttpServletRequest(HttpServletRequest request) {
+    super(request);
+    this.customHeaders = new HashMap<String, String>();
+  }
+
+  public void putHeader(String name, String value) {
+    this.customHeaders.put(name, value);
+  }
+
+  public String getHeader(String name) {
+    String headerValue = customHeaders.get(name);
+
+    if (headerValue != null) {
+      return headerValue;
+    }
+
+    return ((HttpServletRequest) getRequest()).getHeader(name);
+  }
+
+  public Enumeration<String> getHeaderNames() {
+    List<String> names = Collections.list(((HttpServletRequest) getRequest()).getHeaderNames());
+    for (String name : customHeaders.keySet()) {
+      names.add(name);
+    }
+    return Collections.enumeration(names);
+  }
+}

--- a/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/ds/filter/XSODataForwardFilter.java
+++ b/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/ds/filter/XSODataForwardFilter.java
@@ -19,34 +19,43 @@ import java.io.IOException;
 @WebFilter("/*")
 public class XSODataForwardFilter implements Filter {
 
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
-        //
-    }
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    //
+  }
 
-    @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-            throws IOException, ServletException {
-        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-        //only on production case
-        if (httpServletRequest.getHeader("Dirigible-Editor") == null) {
-            String uri = httpServletRequest.getRequestURI();
-            int index = uri.indexOf(".xsodata");
-            if (index > 0) {
-                String parameters = "";
-                if (uri.length() > index + (".xsodata".length() - 1)) {
-                    parameters = uri.substring(index + ".xsodata".length());
-                }
-                RequestDispatcher dispatcher = request.getRequestDispatcher("/odata/v2/" + parameters);
-                dispatcher.forward(request, response);
-            }
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    WrappedHttpServletRequest wrappedHttpServletRequest = new WrappedHttpServletRequest((HttpServletRequest) request);
+
+    //only on production case
+
+    String editorHeader = wrappedHttpServletRequest.getHeader("Dirigible-Editor");
+    String requestMethod = wrappedHttpServletRequest.getMethod();
+
+    if (editorHeader == null && requestMethod.equals("POST")) {
+      wrappedHttpServletRequest.putHeader("Dirigible-Editor", "Workspace");
+    } else if (editorHeader == null) {
+      String uri = wrappedHttpServletRequest.getRequestURI();
+      int index = uri.indexOf(".xsodata");
+      if (index > 0) {
+        String parameters = "";
+        if (uri.length() > index + (".xsodata".length() - 1)) {
+          parameters = uri.substring(index + ".xsodata".length());
         }
-        chain.doFilter(request, response);
+
+        RequestDispatcher dispatcher = request.getRequestDispatcher("/odata/v2/" + parameters);
+        dispatcher.forward(request, response);
+      }
     }
 
-    @Override
-    public void destroy() {
-        //
-    }
+    chain.doFilter(wrappedHttpServletRequest, response);
+  }
+
+  @Override
+  public void destroy() {
+    //
+  }
 
 }

--- a/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/ds/filter/XSODataForwardFilter.java
+++ b/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/ds/filter/XSODataForwardFilter.java
@@ -11,6 +11,7 @@
  */
 package com.sap.xsk.xsodata.ds.filter;
 
+import com.sap.xsk.xsodata.utils.XSKODataWrappedHttpServletRequest;
 import javax.servlet.*;
 import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletRequest;
@@ -27,10 +28,9 @@ public class XSODataForwardFilter implements Filter {
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
-    WrappedHttpServletRequest wrappedHttpServletRequest = new WrappedHttpServletRequest((HttpServletRequest) request);
+    XSKODataWrappedHttpServletRequest wrappedHttpServletRequest = new XSKODataWrappedHttpServletRequest((HttpServletRequest) request);
 
     //only on production case
-
     String editorHeader = wrappedHttpServletRequest.getHeader("Dirigible-Editor");
     String requestMethod = wrappedHttpServletRequest.getMethod();
 

--- a/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/utils/XSKODataWrappedHttpServletRequest.java
+++ b/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/utils/XSKODataWrappedHttpServletRequest.java
@@ -1,4 +1,4 @@
-package com.sap.xsk.xsodata.ds.filter;
+package com.sap.xsk.xsodata.utils;
 
 import java.util.Collections;
 import java.util.Enumeration;
@@ -8,11 +8,11 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 
-final class WrappedHttpServletRequest extends HttpServletRequestWrapper {
+public class XSKODataWrappedHttpServletRequest extends HttpServletRequestWrapper {
 
   private final Map<String, String> customHeaders;
 
-  public WrappedHttpServletRequest(HttpServletRequest request) {
+  public XSKODataWrappedHttpServletRequest(HttpServletRequest request) {
     super(request);
     this.customHeaders = new HashMap<String, String>();
   }


### PR DESCRIPTION
Resolves #673 

Added a `HttpServletRequest` wrapper to the xsodata utils which let's us to add additional headers in the data forward filter as required `Dirigible-Editor` header is missing. 