### PR TITLE
Update pull request test - concurrency

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,5 +1,8 @@
 name: Pull Request
 
+concurrency:
+  group: ${{ github.workflow }}
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Closes sap/fundamental#

Added concurrency ensures that only a single workflow for pull request using the same concurrency group will run at a time.

#### Test

* When you have two pull requests the new one will stay in pending and after pending will change to queuing.

#### Changelog

**New**

* add 
```
concurrency:
  group: ${{ github.workflow }}
```

**Changed**

* before two test run in parallel

**Removed**

*
