### PR TITLE
Handle authentication methods as list for .xsaccess files

### DIFF
--- a/modules/engines/engine-xssecurity/src/main/java/com/sap/xsk/xsaccess/ds/api/IXSKAccessCoreService.java
+++ b/modules/engines/engine-xssecurity/src/main/java/com/sap/xsk/xsaccess/ds/api/IXSKAccessCoreService.java
@@ -18,10 +18,10 @@ public interface IXSKAccessCoreService {
 
   String XSK_FILE_EXTENSION_ACCESS = ".xsaccess";
 
-  XSKAccessDefinition createXSKAccessDefinition(String path, String authenticationMethod, String hash, boolean exposed,
+  XSKAccessDefinition createXSKAccessDefinition(String path, List<String> authenticationMethodAsList, String hash, boolean exposed,
       List<String> authorizationRolesAsList) throws XSKAccessException;
 
-  XSKAccessDefinition updateXSKAccessDefinition(String path, String authenticationMethod, String hash, boolean exposed,
+  XSKAccessDefinition updateXSKAccessDefinition(String path, List<String> authenticationMethodAsList, String hash, boolean exposed,
       List<String> authorizationRolesAsList) throws XSKAccessException;
 
   XSKAccessDefinition getXSKAccessDefinition(String id) throws XSKAccessException;

--- a/modules/engines/engine-xssecurity/src/main/java/com/sap/xsk/xsaccess/ds/model/access/XSKAccessDefinition.java
+++ b/modules/engines/engine-xssecurity/src/main/java/com/sap/xsk/xsaccess/ds/model/access/XSKAccessDefinition.java
@@ -26,8 +26,10 @@ public class XSKAccessDefinition {
   @Column(name = "ACCESS_PATH", columnDefinition = "VARCHAR", nullable = false, length = 255)
   private String path;
 
-  @Column(name = "AUTHENTICATION_METHOD", columnDefinition = "VARCHAR", nullable = false, length = 255)
-  private String authenticationMethod = "Form";
+  @Column(name = "AUTHENTICATION_METHODS", columnDefinition = "BLOB", nullable = false, length = 1000)
+  private byte[] authenticationMethods;
+
+  private List<String> authenticationMethodsAsList;
 
   @Column(name = "AUTHORIZATION_ROLES", columnDefinition = "BLOB", nullable = false, length = 1000)
   private byte[] authorizationRoles;
@@ -65,14 +67,6 @@ public class XSKAccessDefinition {
     this.hash = hash;
   }
 
-  public String getAuthenticationMethod() {
-    return authenticationMethod;
-  }
-
-  public void setAuthenticationMethod(String authenticationMethod) {
-    this.authenticationMethod = authenticationMethod;
-  }
-
   public byte[] getAuthorizationRoles() {
     return authorizationRoles;
   }
@@ -87,6 +81,22 @@ public class XSKAccessDefinition {
 
   public void setAuthorizationRolesAsList(List<String> authorizationRolesAsList) {
     this.authorizationRolesAsList = authorizationRolesAsList;
+  }
+
+  public byte[] getAuthenticationMethods() {
+    return authenticationMethods;
+  }
+
+  public void setAuthenticationMethods(byte[] authenticationMethods) {
+    this.authenticationMethods = authenticationMethods;
+  }
+
+  public List<String> getAuthenticationMethodsAsList() {
+    return authenticationMethodsAsList;
+  }
+
+  public void setAuthenticationMethodsAsList(List<String> authenticationMethodsAsList) {
+    this.authenticationMethodsAsList = authenticationMethodsAsList;
   }
 
   public String getPath() {
@@ -124,7 +134,7 @@ public class XSKAccessDefinition {
     XSKAccessDefinition that = (XSKAccessDefinition) o;
     return exposed == that.exposed &&
         path.equals(that.path) &&
-        authenticationMethod.equals(that.authenticationMethod) &&
+        authenticationMethodsAsList.equals(that.authenticationMethodsAsList) &&
         Arrays.equals(authorizationRoles, that.authorizationRoles) &&
         hash.equals(that.hash) &&
         authorizationRolesAsList.equals(that.authorizationRolesAsList) &&
@@ -134,7 +144,7 @@ public class XSKAccessDefinition {
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(path, authenticationMethod, exposed, hash, authorizationRolesAsList, createdBy, createdAt);
+    int result = Objects.hash(path, authenticationMethodsAsList, exposed, hash, authorizationRolesAsList, createdBy, createdAt);
     result = 31 * result + Arrays.hashCode(authorizationRoles);
     return result;
   }

--- a/modules/engines/engine-xssecurity/src/main/java/com/sap/xsk/xsaccess/ds/service/XSKAccessCoreService.java
+++ b/modules/engines/engine-xssecurity/src/main/java/com/sap/xsk/xsaccess/ds/service/XSKAccessCoreService.java
@@ -39,12 +39,18 @@ public class XSKAccessCoreService implements IXSKAccessCoreService {
   private XSKPrivilegeCoreService xskPrivilegeCoreService = new XSKPrivilegeCoreService();
 
   @Override
-  public XSKAccessDefinition createXSKAccessDefinition(String path, String authenticationMethod, String hash, boolean exposed,
+  public XSKAccessDefinition createXSKAccessDefinition(String path, List<String> authenticationMethodsAsList, String hash, boolean exposed,
       List<String> authorizationRolesAsList) throws XSKAccessException {
     try {
       XSKAccessDefinition xskAccessDefinition = new XSKAccessDefinition();
       xskAccessDefinition.setPath(path);
-      xskAccessDefinition.setAuthenticationMethod(authenticationMethod);
+
+      if (authenticationMethodsAsList == null) {
+        authenticationMethodsAsList = new ArrayList<String>();
+        xskAccessDefinition.setAuthenticationMethodsAsList(new ArrayList<String>());
+      }
+      xskAccessDefinition.setAuthenticationMethods(objectToByteArray(authenticationMethodsAsList));
+
       xskAccessDefinition.setHash(hash);
       xskAccessDefinition.setExposed(exposed);
       if (authorizationRolesAsList == null) {
@@ -75,11 +81,13 @@ public class XSKAccessCoreService implements IXSKAccessCoreService {
   }
 
   @Override
-  public XSKAccessDefinition updateXSKAccessDefinition(String path, String authenticationMethod, String hash, boolean exposed,
+  public XSKAccessDefinition updateXSKAccessDefinition(String path, List<String> authenticationMethodsAsList, String hash, boolean exposed,
       List<String> authorizationRolesAsList) throws XSKAccessException {
     try {
       XSKAccessDefinition xskAccessDefinition = getXSKAccessDefinition(path);
-      xskAccessDefinition.setAuthenticationMethod(authenticationMethod);
+      if (authenticationMethodsAsList != null && !authenticationMethodsAsList.isEmpty()) {
+        xskAccessDefinition.setAuthenticationMethods(objectToByteArray(authenticationMethodsAsList));
+      }
       xskAccessDefinition.setHash(hash);
       xskAccessDefinition.setExposed(exposed);
       if (authorizationRolesAsList != null && !authorizationRolesAsList.isEmpty()) {
@@ -113,6 +121,9 @@ public class XSKAccessCoreService implements IXSKAccessCoreService {
         if (xskAccessDefinition == null) {
           return null;
         }
+
+        List<String> authenticationMethods = XSKUtils.byteArrayToObject(xskAccessDefinition.getAuthenticationMethods());
+        xskAccessDefinition.setAuthenticationMethodsAsList(authenticationMethods);
 
         List<String> authorizationRoles = XSKUtils.byteArrayToObject(xskAccessDefinition.getAuthorizationRoles());
         xskAccessDefinition.setAuthorizationRolesAsList(authorizationRoles);


### PR DESCRIPTION
@ThuF Both a list and a single object is valid in XSC.

closes #550 