### PR TITLE
Added zip class to the util api

### DIFF
--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/util/util.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/util/util.js
@@ -14,10 +14,42 @@ var bytes = require("io/v4/bytes");
 
 exports.codec = require("xsk/util/codec/codec");
 
-exports.createUuid = function() {
-    return uuid.random();
+exports.createUuid = function () {
+  return uuid.random();
 }
 
-exports.stringify = function(arrayBuffer) {
-    return bytes.byteArrayToText(arrayBuffer);
+exports.stringify = function (arrayBuffer) {
+  return bytes.byteArrayToText(arrayBuffer);
+}
+
+exports.Zip = function (zipParams) {
+  zipParams = zipParams || {};
+  var source = zipParams.source || null;
+  var index = zipParams.index || null;
+  var settings = zipParams.settings || {};
+
+  var password = settings.password || null;
+  var maxUncompressedSizeInBytes = settings.maxUncompressedSizeInBytes || null;
+
+  // TODO: Check source type. Currently implemented only for byte array.
+  // TODO: Index must be provided when source is a ResultSet.
+  // TODO: Apply settings if provided.
+
+  if (source) {
+    var zipContent = JSON.parse(bytes.byteArrayToText(source));
+    for (var file in zipContent) {
+      this[file] = zipContent[file];
+    }
+  }
+
+  this._password_; // TODO: Should always return undefined.
+  this._metadata_; // TODO: Should return data about the zip.
+
+  this.asArrayBuffer = function () {
+    var {_password_, _metadata_, asArrayBuffer, ...zipContent} = this;
+    var content = JSON.stringify(zipContent);
+
+    return bytes.textToByteArray(content);
+    ;
+  };
 }

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/util/util.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/util/util.xsjs
@@ -3,11 +3,20 @@ var response = require('http/v4/response');
 var random1 = util.createUuid();
 var random2 = util.createUuid();
 
-var arrayBuffer = [84,104,105,115,32,105,115,32,97,32,85,105,110,116,
-                          56,65,114,114,97,121,32,99,111,110,118,101,114,116,
-                          101,100,32,116,111,32,97,32,115,116,114,105,110,103];
+var arrayBuffer = [84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 85, 105, 110, 116,
+  56, 65, 114, 114, 97, 121, 32, 99, 111, 110, 118, 101, 114, 116,
+  101, 100, 32, 116, 111, 32, 97, 32, 115, 116, 114, 105, 110, 103];
 var convertedBuff = util.stringify(arrayBuffer);
 
+var zipSource = [123, 34, 120, 115, 107, 46, 116, 120, 116, 34, 58, 34, 84, 104, 105, 115, 32, 105, 115, 32, 88, 83, 75, 34, 125];
 
+var zip1 = new util.Zip();
+zip1['xsk.txt'] = 'This is XSK';
+var zip1ArrayBuffer = zip1.asArrayBuffer();
 
-random1 != random2 && convertedBuff === "This is a Uint8Array converted to a string"
+var zip2 = new util.Zip({source: zipSource});
+
+random1 != random2 &&
+convertedBuff === "This is a Uint8Array converted to a string" &&
+JSON.stringify(zip1ArrayBuffer) === JSON.stringify(zipSource) &&
+zip2['xsk.txt'] === 'This is XSK';


### PR DESCRIPTION
Resolves #684 

Added `Zip` class to the util api. Allows the user to create zip objects and download them with the response api using the dirigible `io/v4/zip`.

Members:
- [ ] _password_
- [ ] _metadata_

Methods:
- [x] asArrayBuffer()

TODO:
- [ ] Check source type when making zip from source. Currently implemented only for byte array.
- [ ] Index must be provided when source is a `ResultSet`.
- [ ] Apply settings if provided (`password` and `maxUncompressedSizeInBytes`).

Working sample: 
```javascript
var zip = new $.util.Zip();
zip['xsk.txt'] = 'This is XSK';

$.response.status = $.net.http.OK;
$.response.contentType = 'application/zip';
$.response.headers.set('Content-Disposition', 'attachment; filename = Purchase.zip');
$.response.setBody(zip.asArrayBuffer());
```
