### PR TITLE
Allow constructing new $.web.WebRequest object with parameters

### DIFF
--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/api.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/api.js
@@ -15,23 +15,22 @@
 
 var $ = {};
 
-$.db = require('xsk/db/db');
-$.hdb = require('xsk/hdb/hdb');
-$.net = require('xsk/net/net');
-$.import = require("xsk/import/import").import;
-$.trace = require('xsk/trace/trace');
-$.util = require('xsk/util/util');
-$.jobs = require('xsk/jobs/jobs');
-
 try {
-  let dResponse = require('xsk/web/web').WebResponse;
-  let dRequest = require('xsk/web/web').WebRequest;
+  $.db = require('xsk/db/db');
+  $.hdb = require('xsk/hdb/hdb');
+  $.net = require('xsk/net/net');
+  $.import = require("xsk/import/import").import;
+  $.trace = require('xsk/trace/trace');
+  $.util = require('xsk/util/util');
+  $.jobs = require('xsk/jobs/jobs');
+  $.web = require('xsk/web/web');
   $.session = require('xsk/session/session');
-  $.request = new dRequest();
-  $.response = new dResponse();
   $.security = require('xsk/security/security');
+  $.request = new $.web.WebRequest();
+  $.response = new $.web.WebResponse();
 } catch (e) {
   // $.trace.warning("Caught exception. Api.js is being used by xsk job.")
+  console.error(e.message);
 }
 
 $;

--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/web/web.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/web/web.js
@@ -46,7 +46,7 @@ exports.TupelList = function (dArrayOfContents) {
 
   this.set = function (name, value, options) {
     let element = internalDArrayOfContents.find(function (element) {
-      return element.name === name;
+      return element.name.toUpperCase() === name.toUpperCase();
     });
     if (element) {
       element.value = value;
@@ -128,7 +128,7 @@ Body = function (bodyValue) {
   };
 };
 
-exports.WebRequest = function () {
+exports.WebRequest = function (method, queryPath) {
   const XSJS_FILE_EXTENSION_LENGTH = 5;
   const XSJS_FILE_EXTENSION = ".xsjs";
 
@@ -197,7 +197,9 @@ exports.WebRequest = function () {
 
   this.language = session.language;
 
-  if (dRequest.getMethod() === 'OPTIONS') {
+  if (method) {
+    this.method = method;
+  } else if (dRequest.getMethod() === 'OPTIONS') {
     this.method = http.OPTIONS;
   } else if (dRequest.getMethod() === 'GET') {
     this.method = http.GET;
@@ -230,16 +232,20 @@ exports.WebRequest = function () {
     return dRequestURI.substring(0, filePlaceInURI + XSJS_FILE_EXTENSION_LENGTH);
   }();
 
-  this.queryPath = function () {
-    var dRequestURI = dRequest.getRequestURI();
-    var filePlaceInURI = dRequestURI.search(XSJS_FILE_EXTENSION);
-    return dRequestURI.substring(filePlaceInURI + XSJS_FILE_EXTENSION_LENGTH, dRequestURI.length);
-  }();
+  if (queryPath) {
+    this.queryPath = queryPath;
+  } else {
+    this.queryPath = function () {
+      var dRequestURI = dRequest.getRequestURI();
+      var filePlaceInURI = dRequestURI.search(XSJS_FILE_EXTENSION);
+      return dRequestURI.substring(filePlaceInURI + XSJS_FILE_EXTENSION_LENGTH, dRequestURI.length);
+    }();
+  }
 
   this.contentType = dRequest.getContentType();
 
   this.setBody = function (body, index) {
-    //ToDo;
+    this.body = body;
   };
 
   function transformParametersObject(dParametersObject) {


### PR DESCRIPTION
Resolves #764 

- Now we can make `new $.web.WebRequest` with `method` and `queryPath` params.
- Http client api can use the request to make http requests the same way as $.net.http.Request.