### PR TITLE
Enable testing for asynchronous javascript code

### DIFF
--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/api.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/api.js
@@ -33,4 +33,4 @@ try {
   console.error(e.message);
 }
 
-$;
+module.exports = $;

--- a/modules/engines/engine-xsjs/src/main/java/com/sap/xsk/engine/XSKJavascriptEngineExecutor.java
+++ b/modules/engines/engine-xsjs/src/main/java/com/sap/xsk/engine/XSKJavascriptEngineExecutor.java
@@ -22,6 +22,7 @@ import org.eclipse.dirigible.engine.js.api.IJavascriptModuleSourceProvider;
 import org.eclipse.dirigible.engine.js.graalvm.processor.GraalVMJavascriptEngineExecutor;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +43,8 @@ public class XSKJavascriptEngineExecutor extends GraalVMJavascriptEngineExecutor
   @Override
   protected void beforeEval(Context context) throws IOException {
     String xskApi = getXskApi();
-    context.getBindings(ENGINE_JAVA_SCRIPT).putMember("$", context.eval(ENGINE_JAVA_SCRIPT, xskApi));
+    context.getBindings(ENGINE_JAVA_SCRIPT).putMember("XSK_API", xskApi);
+    context.getBindings(ENGINE_JAVA_SCRIPT).putMember("$", context.eval(ENGINE_JAVA_SCRIPT, "mainModule.loadScriptString(XSK_API)"));
     super.beforeEval(context);
   }
 
@@ -81,7 +83,7 @@ public class XSKJavascriptEngineExecutor extends GraalVMJavascriptEngineExecutor
   @Override
   public Object executeService(String moduleOrCode, Map<Object, Object> executionContext, boolean isModule, boolean commonJSModule)
       throws ScriptingException {
-    return super.executeService(moduleOrCode, executionContext, isModule, false);
+    return super.executeService(moduleOrCode, executionContext, isModule, commonJSModule);
   }
 
   // TODO: Handle XSK Job calls -> callXSKJobFunction(...)

--- a/modules/engines/engine-xsjs/src/test/java/com/sap/xsk/engine/api/test/XSKApiSuiteTest.java
+++ b/modules/engines/engine-xsjs/src/test/java/com/sap/xsk/engine/api/test/XSKApiSuiteTest.java
@@ -12,6 +12,7 @@
 package com.sap.xsk.engine.api.test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -128,10 +129,9 @@ public class XSKApiSuiteTest extends AbstractDirigibleTest {
           extensionsCoreService.createExtensionPoint("/test_extpoint1", "test_extpoint1", "Test");
           extensionsCoreService.createExtension("/test_ext1", "/test_ext_module1", "test_extpoint1", "Test");
 
-          Object result = runTest(executor, repository, testModule);
+          Object error = runTest(executor, repository, testModule);
 
-          assertNotNull(result);
-          assertTrue("API test failed: " + testModule, Boolean.parseBoolean(result.toString()));
+          assertNull("API test failed: " + testModule, error);
 
         } finally {
           extensionsCoreService.removeExtension("/test_ext1");
@@ -174,10 +174,10 @@ public class XSKApiSuiteTest extends AbstractDirigibleTest {
     }
 
     long start = System.currentTimeMillis();
-    Object result = executor.evalModule(testModule, null);
+    Object error = executor.executeServiceModule(testModule, null);
     long time = System.currentTimeMillis() - start;
     System.out.printf("API test [%s] on engine [%s] passed for: %d ms%n", testModule, executor.getType(), time);
-    return result;
+    return error;
   }
 
   private class StubServletOutputStream extends ServletOutputStream {

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/callable-statement.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/callable-statement.xsjs
@@ -1,4 +1,5 @@
 var db = $.db;
+var assertTrue = require('utils/assert').assertTrue;
 
 var connection = db.getConnection();
 
@@ -64,4 +65,4 @@ call.setTimestamp(15, timestampInput);
 
 call.setTinyInt(16, 1);
 
-true
+assertTrue(true);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/connection.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/connection.xsjs
@@ -1,5 +1,5 @@
 var db = $.db;
-
+var assertTrue = require('utils/assert').assertTrue;
 // tests isClosed() too
 function close(){
   var connection = db.getConnection();
@@ -26,4 +26,4 @@ function prepareStatement(){
   return statement.constructor.name == "XscPreparedStatement"
 }
 
-close() && prepareCall() && prepareStatement();
+assertTrue(close() && prepareCall() && prepareStatement());

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/db.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/db.xsjs
@@ -1,5 +1,5 @@
 var db = $.db;
-
+var assertTrue = require('utils/assert').assertTrue;
 var connection = db.getConnection();
 
-connection != null && connection != undefined;
+assertTrue(connection != null && connection != undefined);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/parameter-metadata.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/parameter-metadata.xsjs
@@ -15,6 +15,7 @@ connection.prepareCall(createTable).execute();
 var statement = connection.prepareStatement(insert);
 var parameterMetaData = statement.getParameterMetaData();
 var count = parameterMetaData.getParameterCount();
+var assertTrue = require('utils/assert').assertTrue;
 
 var assertions = [];
 for (var i = 1; i <= count; i++) {
@@ -31,4 +32,4 @@ for (var i = 1; i <= count; i++) {
 statement.close();
 connection.close();
 
-assertions.every((assertion) => assertion);
+assertTrue(assertions.every((assertion) => assertion));

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/prepared-statement.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/prepared-statement.xsjs
@@ -1,5 +1,5 @@
 var db = $.db;
-
+var assertTrue = require('utils/assert').assertTrue;
 var connection = db.getConnection();
 
 try {
@@ -44,7 +44,7 @@ try {
   closeAssertion = false;
 } catch {}
 
-batchExecutes == 2 && !executeResult && closeAssertion && updatedRows == 3 && metadataAssertion && moreResultsAssertion && parameterMetaDataAssertion && isClosedAssertion && closeAssertion;
+assertTrue(batchExecutes == 2 && !executeResult && closeAssertion && updatedRows == 3 && metadataAssertion && moreResultsAssertion && parameterMetaDataAssertion && isClosedAssertion && closeAssertion);
 
 function setStatementFields() {
   var inputStream = Java.type('java.io.ByteArrayInputStream');

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/result-set.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/result-set.xsjs
@@ -1,4 +1,5 @@
 var db = $.db;
+var assertTrue = require('utils/assert').assertTrue;
 
 var connection = db.getConnection();
 
@@ -41,7 +42,7 @@ try {
   closeAssertion = false;
 } catch {}
 
-bigIntAssertion && dateAssertion && decAssertion && doubleAssertion && intAssertion && stringAssertion && timeAssertion && timestampAssertion && closeAssertion && isClosedAssertion;
+assertTrue(bigIntAssertion && dateAssertion && decAssertion && doubleAssertion && intAssertion && stringAssertion && timeAssertion && timestampAssertion && closeAssertion && isClosedAssertion);
 
 function setStatementFields() {
   var inputStream = Java.type('java.io.ByteArrayInputStream');

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/resultset-metadata.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/db/api/resultset-metadata.xsjs
@@ -1,4 +1,5 @@
 var db = $.db;
+var assertTrue = require('utils/assert').assertTrue;
 
 var connection = db.getConnection();
 
@@ -32,4 +33,4 @@ var scaleAssertion = metadata.getScale(1) == 0;
 
 var tableNameAssertion = metadata.getTableName(1) == "TEST_USERS";
 
-columnCountAssertion && labelAssertion && nameAssertion && typeAssertion && typeNameAssertion && precisionAssertion && scaleAssertion && tableNameAssertion
+assertTrue(columnCountAssertion && labelAssertion && nameAssertion && typeAssertion && typeNameAssertion && precisionAssertion && scaleAssertion && tableNameAssertion);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/hdb/column-metadata.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/hdb/column-metadata.xsjs
@@ -1,5 +1,6 @@
 var hdb = $.hdb;
 var response = require('http/v4/response');
+var assertTrue = require('utils/assert').assertTrue;
 
 var conn = hdb.getConnection();
 conn.executeUpdate('CREATE SCHEMA EXAMPLE');
@@ -37,4 +38,4 @@ for (var i = 0; i < columnCount; i++) {
 response.contentType = "text/plain";
 response.println(body);
 
-conn != null&& resultSet != null && columnCount !=null && body != null && lastColumnName ==="WEIGHT"&& lastColumnTypeName==="DOUBLE";
+assertTrue(conn != null&& resultSet != null && columnCount !=null && body != null && lastColumnName ==="WEIGHT"&& lastColumnTypeName==="DOUBLE");

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/hdb/connection-execute-query.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/hdb/connection-execute-query.xsjs
@@ -1,5 +1,6 @@
 var database = $.hdb;
 var response = require('http/v4/response');
+var assertTrue = require('utils/assert').assertTrue;
 
 try {
 	var connection = database.getConnection();
@@ -29,4 +30,4 @@ try {
 response.flush();
 response.close();
 
-resultSet[0][1].toString() == "IVAN" && resultSet2.length.toString() == 2
+assertTrue(resultSet[0][1].toString() == "IVAN" && resultSet2.length.toString() == 2);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/hdb/connection-execute-update.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/hdb/connection-execute-update.xsjs
@@ -1,5 +1,6 @@
 var db = $.hdb;
  var response = require('http/v4/response');
+ var assertTrue = require('utils/assert').assertTrue;
    var connection = db.getConnection();
    var insertStatement = "INSERT INTO EXAMPLE.TEST_USERS (ID, FIRSTNAME, LASTNAME, AGE, WEIGHT) VALUES (?,?,?,?,?)";
  	var insertResult = connection.executeUpdate(insertStatement, 4, 'PETKO', 'MOMCHEV', 24 ,89);
@@ -20,4 +21,4 @@ var db = $.hdb;
  	response.println("Warnings: " + connection.getLastWarning());
  	response.println("is connection closed: " + connection.isClosed());
 
-  insertResult ===1 && updateResult === 4
+  assertTrue(insertResult ===1 && updateResult === 4);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/hdb/result-set.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/hdb/result-set.xsjs
@@ -1,5 +1,6 @@
 var hdb = $.hdb;
 var response = require('http/v4/response');
+var assertTrue = require('utils/assert').assertTrue;
 
 try {
 	var connection = hdb.getConnection();
@@ -27,4 +28,4 @@ try {
 	connection.close();
 }
 
-row0['FIRSTNAME'] === "IVAN" && row0['LASTNAME']==="VOLKOV" && row0['AGE']===29
+assertTrue(row0['FIRSTNAME'] === "IVAN" && row0['LASTNAME']==="VOLKOV" && row0['AGE']===29);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/hdb/resultset-metadata.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/hdb/resultset-metadata.xsjs
@@ -1,5 +1,6 @@
 var db = $.hdb;
 var response = require('http/v4/response');
+var assertTrue = require('utils/assert').assertTrue;
 
 var connection = db.getConnection();
 var result = connection.executeQuery('SELECT * FROM EXAMPLE.TEST_USERS');
@@ -9,4 +10,4 @@ var metadata = result.metadata;
 // conn.executeUpdate('DROP SCHEMA EXAMPLE');
 response.println(JSON.stringify(metadata));
 
- metadata != null
+assertTrue(metadata != null);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/http/http.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/http/http.xsjs
@@ -1,5 +1,5 @@
 let http = $.net.http;
-
+var assertTrue = require('utils/assert').assertTrue;
 let client = new http.Client();
 let request = new http.Request(http.GET, "/");
 let destination = new http.Destination()
@@ -12,4 +12,4 @@ client.setTimeout(10);
 client.request(request, destination);
 let response = client.getResponse();
 
-response.status === http.OK && response.cookies != null && response.headers != null && response.body != null
+assertTrue(response.status === http.OK && response.cookies != null && response.headers != null && response.body != null);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/import/import.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/import/import.xsjs
@@ -1,6 +1,6 @@
 // Importing xsjs lib and adding the module to the $ object.
 $.import("test.xsk.import.sap.test.lib", "basic");
-
+var assertTrue = require('utils/assert').assertTrue;
 // Assigning the module to a variable from the $ object.
 var mathbasic = $.test.xsk.import.sap.test.lib.basic;
 
@@ -17,5 +17,5 @@ var multiply = mathlib.multiply(4, 9);
 var division = mathlib.division(9, 3);
 
 // Verifying the results.
-square === 36 && multiply === 36 && division === 3 && sum === 10 && sub === 5
+assertTrue(square === 36 && multiply === 36 && division === 3 && sum === 10 && sub === 5);
 

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/net/net.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/net/net.xsjs
@@ -1,5 +1,5 @@
 let net = $.net;
-
+var assertTrue = require('utils/assert').assertTrue;
 let mail = new net.Mail({
   sender: {address: "sender@sap.com"},
   to: [{name: "John Doe", address: "john.doe@sap.com", nameEncoding: "US-ASCII"}, {name: "Jane Doe", address: "jane.doe@sap.com"}],
@@ -21,4 +21,4 @@ let to = mail.to.map(e => e.address)
 let cc = mail.cc.map(e => e.address)
 let bcc = mail.bcc.map(e => e.address)
 
-to !== "" && to !== undefined && cc !== "" && cc !== undefined && bcc !== "" && bcc !== undefined && smtp.isClosed()
+assertTrue(to !== "" && to !== undefined && cc !== "" && cc !== undefined && bcc !== "" && bcc !== undefined && smtp.isClosed());

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/request/request.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/request/request.xsjs
@@ -9,5 +9,3 @@ $.request.path;
 $.request.queryPath;
 
 // ToDo $.request.setBody
-
-true

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/response/response.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/response/response.xsjs
@@ -1,5 +1,3 @@
 $.response.contentType = "text/html";
 $.response.status = $.net.http.OK;
 $.response.setBody("My Personal Library");
-
-true

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/session/session.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/session/session.xsjs
@@ -1,3 +1,4 @@
+var assertTrue = require('utils/assert').assertTrue;
 let username = $.session.getUsername()
 let appPrivileges = $.session.hasAppPrivilege("Developer")
 if (appPrivileges) {
@@ -25,4 +26,4 @@ $.response.setBody("Timeout: " +timeout);
 $.response.setBody("Token: " +token);
 $.response.setBody("Auth Type: " +authType);
 
-username === "tester" && appPrivileges !== null && sysPrivileges != null && timeout !== null && authType !== null && token != null
+assertTrue(username === "tester" && appPrivileges !== null && sysPrivileges != null && timeout !== null && authType !== null && token != null);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/trace/trace.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/trace/trace.xsjs
@@ -1,3 +1,4 @@
+var assertTrue = require('utils/assert').assertTrue;
 let trace = $.trace;
 
 let debugBool = trace.isDebugEnabled();
@@ -22,4 +23,4 @@ if (warnBool) {
     trace.warning("Warning message!");
 }
 
-debugBool && errorBool && fatalBool && infoBool && warnBool
+assertTrue(debugBool && errorBool && fatalBool && infoBool && warnBool);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/util/codec/codec.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/util/codec/codec.xsjs
@@ -1,3 +1,4 @@
+var assertTrue = require('utils/assert').assertTrue;
 var codec = $.util.codec;
 var util = $.util;
 
@@ -13,4 +14,4 @@ var valueFromBase64 = util.stringify(decodedBase64);
 
 
 
-valueFromHex === "dirigible as hex" && valueFromBase64 ==="dirigible as base64"
+assertTrue(valueFromHex === "dirigible as hex" && valueFromBase64 ==="dirigible as base64");

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/util/util.xsjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/util/util.xsjs
@@ -1,3 +1,4 @@
+var assertTrue = require('utils/assert').assertTrue;
 var util = $.util;
 var response = require('http/v4/response');
 var random1 = util.createUuid();
@@ -16,7 +17,8 @@ var zip1ArrayBuffer = zip1.asArrayBuffer();
 
 var zip2 = new util.Zip({source: zipSource});
 
-random1 != random2 &&
+assertTrue(random1 != random2 &&
 convertedBuff === "This is a Uint8Array converted to a string" &&
 JSON.stringify(zip1ArrayBuffer) === JSON.stringify(zipSource) &&
-zip2['xsk.txt'] === 'This is XSK';
+zip2['xsk.txt'] === 'This is XSK'
+)


### PR DESCRIPTION
In order to test async code XSKApiSuiteTest needs to load xsjs services as modules instead of ```eval```-ing them. This is why xsk api is now loaded as a cjs module.

#437 
