### PR TITLE
Fix datasource NPE when obtaining DB connection

### DIFF
--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/module/XSKHDBModule.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/module/XSKHDBModule.java
@@ -44,30 +44,41 @@ import com.sap.xsk.hdb.ds.service.manager.IXSKViewManagerService;
 
 public class XSKHDBModule extends AbstractDirigibleModule {
 
-  private static final Map<String, IXSKDataStructureManager> MANAGER_SERVICES = bindManagerServicesToFileExtensions();
+  private static Map<String, IXSKDataStructureManager> managerServices;
 
-  private static final Map<String, XSKDataStructureParser> PARSER_SERVICES = bindParsersToFileExtension();
+  private static Map<String, XSKDataStructureParser> parserServices;
 
-  private static final Map<String, String> PARSER_TYPES = bindParserTypeToFileExtension();
+  private static Map<String, String> parserTypes;
 
   public static synchronized Map<String, IXSKDataStructureManager> getManagerServices() {
-    return MANAGER_SERVICES;
+    if (managerServices == null) {
+      managerServices = new HashMap<String, IXSKDataStructureManager>();
+      bindManagerServicesToFileExtensions(managerServices);
+    }
+    return managerServices;
   }
 
   public static synchronized Map<String, XSKDataStructureParser> getParserServices() {
-    return PARSER_SERVICES;
+    if (parserServices == null) {
+      parserServices = new HashMap<String, XSKDataStructureParser>();
+      bindParsersToFileExtension(parserServices);
+    }
+    return parserServices;
   }
 
   public static synchronized Map<String, String> getParserTypes() {
-    return PARSER_TYPES;
+    if (parserTypes == null) {
+      parserTypes = new HashMap<String, String>();
+      bindParserTypeToFileExtension(parserTypes);
+    }
+    return parserTypes;
   }
 
   @Override
   public void configure() {
   }
 
-  private static Map<String, IXSKDataStructureManager> bindManagerServicesToFileExtensions() {
-    Map<String, IXSKDataStructureManager> managerServices = new HashMap<>();
+  private static void bindManagerServicesToFileExtensions(Map<String, IXSKDataStructureManager> managerServices) {
     managerServices.put(IXSKDataStructureModel.TYPE_HDBDD, new IXSKEntityManagerService());
     managerServices.put(IXSKDataStructureModel.TYPE_HDB_TABLE, new IXSKTableManagerService());
     managerServices.put(IXSKDataStructureModel.TYPE_HDB_VIEW, new IXSKViewManagerService());
@@ -78,12 +89,9 @@ public class XSKHDBModule extends AbstractDirigibleModule {
     managerServices.put(IXSKDataStructureModel.TYPE_HDB_SEQUENCE, new IXSKHDBSequenceManagerService());
     managerServices.put(IXSKDataStructureModel.TYPE_HDB_SCALARFUNCTION, new IXSKScalarFunctionManagerService());
     managerServices.put(IXSKDataStructureModel.TYPE_HDB_TABLE_TYPE, new IXSKTableTypeManagerService());
-
-    return managerServices;
   }
 
-  private static Map<String, XSKDataStructureParser> bindParsersToFileExtension() {
-    Map<String, XSKDataStructureParser> parserServices = new HashMap<>();
+  private static void bindParsersToFileExtension(Map<String, XSKDataStructureParser> parserServices) {
     parserServices.put(IXSKDataStructureModel.FILE_EXTENSION_ENTITIES, new XSKHdbddParser());
     parserServices.put(IXSKDataStructureModel.FILE_EXTENSION_TABLE, new XSKTableParser());
     parserServices.put(IXSKDataStructureModel.FILE_EXTENSION_VIEW, new XSKViewParser());
@@ -105,12 +113,9 @@ public class XSKHDBModule extends AbstractDirigibleModule {
     parserServices.put(IXSKDataStructureModel.TYPE_HDB_SEQUENCE, new XSKHDBSequenceParser());
     parserServices.put(IXSKDataStructureModel.TYPE_HDB_SCALARFUNCTION, new XSKHDBScalarFunctionParser());
     parserServices.put(IXSKDataStructureModel.TYPE_HDB_TABLE_TYPE, new XSKTableTypeParser());
-
-    return parserServices;
   }
 
-  private static Map<String, String> bindParserTypeToFileExtension() {
-    Map<String, String> parserTypes = new HashMap<>();
+  private static void bindParserTypeToFileExtension(Map<String, String> parserTypes) {
     parserTypes.put(IXSKDataStructureModel.FILE_EXTENSION_ENTITIES, IXSKDataStructureModel.TYPE_HDBDD);
     parserTypes.put(IXSKDataStructureModel.FILE_EXTENSION_TABLE, IXSKDataStructureModel.TYPE_HDB_TABLE);
     parserTypes.put(IXSKDataStructureModel.FILE_EXTENSION_VIEW, IXSKDataStructureModel.TYPE_HDB_VIEW);
@@ -121,8 +126,6 @@ public class XSKHDBModule extends AbstractDirigibleModule {
     parserTypes.put(IXSKDataStructureModel.FILE_EXTENSION_HDBSEQUENCE, IXSKDataStructureModel.TYPE_HDB_SEQUENCE);
     parserTypes.put(IXSKDataStructureModel.FILE_EXTENSION_HDBSCALARFUNCTION, IXSKDataStructureModel.TYPE_HDB_SCALARFUNCTION);
     parserTypes.put(IXSKDataStructureModel.FILE_EXTENSION_STRUCTURE, IXSKDataStructureModel.TYPE_HDB_TABLE_TYPE);
-
-    return parserTypes;
   }
 
   @Override


### PR DESCRIPTION
Revert changes from https://github.com/SAP/xsk/commit/ab8c9293f22e90e6435bc566664c8530dcbee2e8

This causes SYSTEM_DATASOURCE to be null and creates NPE further on. Needs further investigation for the exact reason.