### PR TITLE
Allow xsodata entity definition use synonym

### DIFF
--- a/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/utils/XSKODataUtils.java
+++ b/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/utils/XSKODataUtils.java
@@ -21,6 +21,7 @@ import com.sap.xsk.xsodata.ds.service.XSKODataCoreService;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.olingo.odata2.api.edm.EdmMultiplicity;
@@ -105,6 +106,17 @@ public class XSKODataUtils {
         PersistenceTableModel tableMetadata = dbMetadataUtil
             .getTableMetadata(tableName, dbMetadataUtil.getOdataArtifactTypeSchema(tableName));
         List<PersistenceTableColumnModel> allEntityDbColumns = tableMetadata.getColumns();
+
+        if (ISqlKeywords.METADATA_SYNONYM.equals(tableMetadata.getTableType())) {
+          HashMap<String, String> targetObjectMetadata = dbMetadataUtil.getSynonymTargetObjectMetadata(tableMetadata.getTableName());
+
+          if (targetObjectMetadata.isEmpty()) {
+            logger.error("Failed to get details for synonym - " + tableMetadata.getTableName());
+            continue;
+          }
+
+          tableMetadata = dbMetadataUtil.getTableMetadata(targetObjectMetadata.get(ISqlKeywords.KEYWORD_TABLE), targetObjectMetadata.get(ISqlKeywords.KEYWORD_SCHEMA));
+        }
 
         if (ISqlKeywords.METADATA_CALC_VIEW.equals(tableMetadata.getTableType()) && entity.getWithPropertyProjections().isEmpty() && entity
             .getWithoutPropertyProjections().isEmpty()) {

--- a/modules/engines/engine-xsodata/src/test/resources/entity_synonym.xsodata
+++ b/modules/engines/engine-xsodata/src/test/resources/entity_synonym.xsodata
@@ -1,0 +1,16 @@
+service namespace "np" {
+
+    "TestCalcView" as "CalcView1"
+        keys generate local "ID";
+
+    "TestCalcView" as "CalcView2"  without("COLUMN1","COLUMN3")
+        keys generate local "ID";
+
+    "TestCalcView" as "CalcView3"  with("COLUMN1","COLUMN3")
+        keys generate local "ID";
+
+}
+
+annotations {
+	  enable OData4SAP;
+}


### PR DESCRIPTION
Resolves #823 

`XSKODataParser` checks if the entity definition is a synonym when applying keys and parameters condition and in case it is uses the synonym's target object. Also the same check is done in `XSKODataUtils` when converting xsodata model to xsodata definition.