### PR TITLE
grant HDI container privileges on external artefacts' schemas

### DIFF
--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/model/hdbsynonym/XSKHDBSYNONYMDefinitionModel.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/model/hdbsynonym/XSKHDBSYNONYMDefinitionModel.java
@@ -57,6 +57,13 @@ public class XSKHDBSYNONYMDefinitionModel {
     String object;
     String schema;
 
+    public Target() {}
+
+    public Target(String object, String schema) {
+      this.object = object;
+      this.schema = schema;
+    }
+
     public String getObject() {
       return object;
     }

--- a/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/processors/hdi/XSKGrantPrivilegesExternalArtifactsSchemaProcessor.java
+++ b/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/processors/hdi/XSKGrantPrivilegesExternalArtifactsSchemaProcessor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and XSK contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and XSK contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.xsk.hdb.ds.processors.hdi;
+
+import com.sap.xsk.hdb.ds.model.hdbsynonym.XSKDataStructureHDBSynonymModel;
+import com.sap.xsk.hdb.ds.model.hdbsynonym.XSKHDBSYNONYMDefinitionModel;
+import org.apache.commons.io.FilenameUtils;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map.Entry;
+
+
+public class XSKGrantPrivilegesExternalArtifactsSchemaProcessor extends XSKHDIAbstractProcessor {
+
+  public final void execute(Connection connection, String container, String[] deploys,
+      XSKDataStructureHDBSynonymModel synonymModel) throws SQLException {
+    String containerOwner = container + "#OO";
+    for (String deploy : deploys) {
+      if (FilenameUtils.getExtension(deploy).equalsIgnoreCase("hdbsynonym")) {
+        for (Entry<String, XSKHDBSYNONYMDefinitionModel> synonymDefinition : synonymModel.getSynonymDefinitions().entrySet()) {
+          String externalArtifactSchema = synonymDefinition.getValue().getTarget().getSchema();
+          executeUpdate(connection,
+              "GRANT SELECT ON SCHEMA \"" + externalArtifactSchema + "\" TO \"" + containerOwner + "\" WITH GRANT OPTION;");
+          executeUpdate(connection,
+              "GRANT EXECUTE ON SCHEMA \"" + externalArtifactSchema + "\" TO \"" + containerOwner + "\" WITH GRANT OPTION;");
+        }
+      }
+    }
+  }
+}

--- a/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/processors/hdi/XSKHDIAbstractProcessor.java
+++ b/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/processors/hdi/XSKHDIAbstractProcessor.java
@@ -34,7 +34,7 @@ public abstract class XSKHDIAbstractProcessor {
 	 * @param parameters - SQL parameters
 	 * @throws SQLException - in case of failure
 	 */
-	protected void executeUpdate(Connection connection, String sql, String... parameters) throws SQLException {
+  public void executeUpdate(Connection connection, String sql, String... parameters) throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement(sql)) {
 			setStatementParams(statement, parameters);
 			statement.executeUpdate();

--- a/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/processors/hdi/XSKHDIContainerCreateProcessor.java
+++ b/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/processors/hdi/XSKHDIContainerCreateProcessor.java
@@ -11,6 +11,7 @@
  */
 package com.sap.xsk.hdb.ds.processors.hdi;
 
+import com.sap.xsk.hdb.ds.model.hdbsynonym.XSKDataStructureHDBSynonymModel;
 import com.sap.xsk.hdb.ds.model.hdi.XSKDataStructureHDIModel;
 import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
@@ -35,6 +36,10 @@ public class XSKHDIContainerCreateProcessor {
   private XSKDeployContainerContentProcessor deployContainerContentProcessor = new XSKDeployContainerContentProcessor();
   private XSKGrantPrivilegesContainerSchemaProcessor grantPrivilegesContainerSchemaProcessor = new XSKGrantPrivilegesContainerSchemaProcessor();
   private XSKGrantPrivilegesContainerTargetSchemaProcessor grantPrivilegesContainerTargetSchemaProcessor = new XSKGrantPrivilegesContainerTargetSchemaProcessor();
+  private XSKGrantPrivilegesExternalArtifactsSchemaProcessor grantPrivilegesExternalArtifactsSchemaProcessor = new XSKGrantPrivilegesExternalArtifactsSchemaProcessor();
+  //TODO
+  //Once the processing of artifacts is adjusted to have separate one for HDI container's artifacts should be fixed and the synonym model shouldn't be empty
+  private XSKDataStructureHDBSynonymModel synonymModel = new XSKDataStructureHDBSynonymModel();
 
   public void execute(Connection connection, XSKDataStructureHDIModel hdiModel) {
     LOGGER.info("Start processing HDI Containers...");
@@ -64,6 +69,9 @@ public class XSKHDIContainerCreateProcessor {
 
       // Grant Privileges on the Target Schema
       this.grantPrivilegesContainerTargetSchemaProcessor.execute(connection, hdiModel.getContainer(), hdiModel.getUsers());
+
+      //Grant Privileges on the external artifacts' schemas
+      this.grantPrivilegesExternalArtifactsSchemaProcessor.execute(connection,hdiModel.getContainer(), hdiModel.getDeploy(), synonymModel);
 
       // Deploy the Content
       this.deployContainerContentProcessor.execute(connection, hdiModel.getContainer(), hdiModel.getDeploy(), hdiModel.getUndeploy());

--- a/modules/engines/engine-hdi/src/test/java/com/sap/xsk/hdi/processors/XSKGrantPrivilegesExternalArtifactsSchemaProcessorTest.java
+++ b/modules/engines/engine-hdi/src/test/java/com/sap/xsk/hdi/processors/XSKGrantPrivilegesExternalArtifactsSchemaProcessorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and XSK contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and XSK contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.xsk.hdi.processors;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.sap.xsk.hdb.ds.model.hdbsynonym.XSKDataStructureHDBSynonymModel;
+import com.sap.xsk.hdb.ds.model.hdbsynonym.XSKHDBSYNONYMDefinitionModel;
+import com.sap.xsk.hdb.ds.model.hdbsynonym.XSKHDBSYNONYMDefinitionModel.Target;
+import com.sap.xsk.hdb.ds.processors.hdi.XSKGrantPrivilegesExternalArtifactsSchemaProcessor;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public class XSKGrantPrivilegesExternalArtifactsSchemaProcessorTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Connection mockConnection;
+
+  @Test
+  public void executeGrantPrivilegesExternalArtifactsSchemaSuccessfully() throws SQLException {
+    XSKGrantPrivilegesExternalArtifactsSchemaProcessor processorSpy = spy(XSKGrantPrivilegesExternalArtifactsSchemaProcessor.class);
+
+    String mockSQLSelect = "GRANT SELECT ON SCHEMA \"externalSchema1\" TO \"testContainer#OO\" WITH GRANT OPTION;";
+    String mockSQLExecute = "GRANT EXECUTE ON SCHEMA \"externalSchema1\" TO \"testContainer#OO\" WITH GRANT OPTION;";
+    String container = "testContainer";
+    String[] deploys = {"/com/sap/testSynonym.hdbsynonym"};
+    XSKDataStructureHDBSynonymModel synonymModel = new XSKDataStructureHDBSynonymModel();
+    XSKHDBSYNONYMDefinitionModel synonymDefinitionModel = new XSKHDBSYNONYMDefinitionModel();
+    synonymDefinitionModel.setTarget(new Target("externalArtefact1", "externalSchema1"));
+    synonymModel.setSynonymDefinitions(Map.of("synonymDef1", synonymDefinitionModel));
+
+
+    processorSpy.execute(mockConnection, container, deploys, synonymModel);
+    verify(processorSpy, times(1)).executeUpdate(mockConnection,mockSQLSelect, new String[]{});
+    verify(processorSpy, times(1)).executeUpdate(mockConnection,mockSQLExecute, new String[]{});
+  }
+}


### PR DESCRIPTION
Closes #790 

Depends on https://github.com/SAP/xsk/issues/792
To be merged when the fix for #792 is provided 

#### Changelog

**New**

Adding logic for granting privileges on external for HDI container artefacts' schemas 

