### PR TITLE
#944-keeping sync state when parsing of artefacts fails

### DIFF
--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/model/hdbsynonym/XSKHDBSYNONYMDefinitionModel.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/model/hdbsynonym/XSKHDBSYNONYMDefinitionModel.java
@@ -80,15 +80,17 @@ public class XSKHDBSYNONYMDefinitionModel {
       this.schema = schema;
     }
 
-    public void checkForAllMandatoryFieldsPresence() {
-      checkPresence(object, "object");
-      checkPresence(schema, "schema");
-    }
+  }
 
-    private <T> void checkPresence(T field, String fieldName) {
-      if (Objects.isNull(field)) {
-        throw new XSKHDBSYNONYMMissingPropertyException(String.format("Missing mandatory field %s!", fieldName));
-      }
+  public void checkForAllMandatoryFieldsPresence() {
+    checkPresence(target, "target");
+    checkPresence(this.getTarget().getObject(), "object");
+    checkPresence(this.getTarget().getSchema(), "schema");
+  }
+
+  private <T> void checkPresence(T field, String fieldName) {
+    if (Objects.isNull(field)) {
+      throw new XSKHDBSYNONYMMissingPropertyException(String.format("Missing mandatory field %s!", fieldName));
     }
   }
 }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbdd/XSKHdbddParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbdd/XSKHdbddParser.java
@@ -14,6 +14,7 @@ package com.sap.xsk.hdb.ds.parser.hdbdd;
 import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
+import com.sap.xsk.hdb.ds.artefacts.HDBDDEntitySynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModel;
 import com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureCdsModel;
@@ -21,6 +22,7 @@ import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableModel;
 import com.sap.xsk.hdb.ds.model.hdbtabletype.XSKDataStructureHDBTableTypeModel;
 import com.sap.xsk.hdb.ds.module.XSKHDBModule;
 import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
+import com.sap.xsk.hdb.ds.synchronizer.XSKDataStructuresSynchronizer;
 import com.sap.xsk.hdb.ds.transformer.hdbdd.HdbddTransformer;
 import com.sap.xsk.parser.hdbdd.core.CdsLexer;
 import com.sap.xsk.parser.hdbdd.core.CdsParser;
@@ -50,6 +52,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.eclipse.dirigible.api.v3.security.UserFacade;
 import org.eclipse.dirigible.commons.config.StaticObjects;
+import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IResource;
 import org.slf4j.Logger;
@@ -64,6 +67,8 @@ public class XSKHdbddParser implements XSKDataStructureParser {
   private SymbolTable symbolTable = new SymbolTable();
   private Map<String, Set<String>> dependencyStructure = new HashMap<>();
   private Set<String> parsedNodes = new HashSet<>();
+  private HDBDDEntitySynchronizationArtefactType ENTITY_ARTEFACT = new HDBDDEntitySynchronizationArtefactType();
+  private XSKDataStructuresSynchronizer dataStructuresSynchronizer = new XSKDataStructuresSynchronizer();
 
   @Override
   public XSKDataStructureModel parse(String location, String content) throws XSKDataStructuresException, IOException {
@@ -119,6 +124,7 @@ public class XSKHdbddParser implements XSKDataStructureParser {
       XSKCommonsUtils.logCustomErrors(location, XSKCommonsConstants.PARSER_ERROR, "", "", e.getMessage(),
           "", XSKCommonsConstants.HDBDD_PARSER, XSKCommonsConstants.MODULE_PARSERS,
           XSKCommonsConstants.SOURCE_PUBLISH_REQUEST, XSKCommonsConstants.PROGRAM_XSK);
+      dataStructuresSynchronizer.applyArtefactState(XSKCommonsUtils.getRepositoryBaseObjectName(location),location,ENTITY_ARTEFACT, ArtefactState.FAILED_CREATE, e.getMessage());
       throw new CDSRuntimeException(String.format("Failed to parse file: %s. %s", location, e.getMessage()));
     }
 
@@ -139,6 +145,7 @@ public class XSKHdbddParser implements XSKDataStructureParser {
         XSKCommonsUtils.logCustomErrors(location, XSKCommonsConstants.PARSER_ERROR, "", "", e.getMessage(),
             "", XSKCommonsConstants.HDBDD_PARSER, XSKCommonsConstants.MODULE_PARSERS,
             XSKCommonsConstants.SOURCE_PUBLISH_REQUEST, XSKCommonsConstants.PROGRAM_XSK);
+        dataStructuresSynchronizer.applyArtefactState(XSKCommonsUtils.getRepositoryBaseObjectName(location),location,ENTITY_ARTEFACT, ArtefactState.FAILED_CREATE, e.getMessage());
       }
     });
 
@@ -155,6 +162,7 @@ public class XSKHdbddParser implements XSKDataStructureParser {
       XSKCommonsUtils.logCustomErrors(location, XSKCommonsConstants.PARSER_ERROR, "", "", e.getMessage(),
           "", XSKCommonsConstants.HDBDD_PARSER, XSKCommonsConstants.MODULE_PARSERS,
           XSKCommonsConstants.SOURCE_PUBLISH_REQUEST, XSKCommonsConstants.PROGRAM_XSK);
+      dataStructuresSynchronizer.applyArtefactState(XSKCommonsUtils.getRepositoryBaseObjectName(location),location,ENTITY_ARTEFACT, ArtefactState.FAILED_CREATE, e.getMessage());
       throw new CDSRuntimeException(String.format("Failed to parse file: %s. %s", location, e.getMessage()));
     }
   }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbtable/XSKTableParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbtable/XSKTableParser.java
@@ -16,6 +16,7 @@ import com.google.gson.JsonElement;
 import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
+import com.sap.xsk.hdb.ds.artefacts.HDBTableSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintPrimaryKeyModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintUniqueModel;
@@ -23,6 +24,7 @@ import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintsMode
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableIndexModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableModel;
 import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
+import com.sap.xsk.hdb.ds.synchronizer.XSKDataStructuresSynchronizer;
 import com.sap.xsk.hdb.ds.transformer.HDBTableDefinitionModelToHDBTableColumnModelTransformer;
 import com.sap.xsk.parser.hdbtable.core.HdbtableLexer;
 import com.sap.xsk.parser.hdbtable.core.HdbtableParser;
@@ -47,6 +49,7 @@ import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +57,8 @@ public class XSKTableParser implements XSKDataStructureParser<XSKDataStructureHD
 
   private static final Logger logger = LoggerFactory.getLogger(XSKTableParser.class);
   private HDBTableDefinitionModelToHDBTableColumnModelTransformer columnModelTransformer = new HDBTableDefinitionModelToHDBTableColumnModelTransformer();
+  private static final HDBTableSynchronizationArtefactType TABLE_ARTEFACT = new HDBTableSynchronizationArtefactType();
+  private static final XSKDataStructuresSynchronizer dataStructuresSynchronizer = new XSKDataStructuresSynchronizer();
 
   @Override
   public String getType() {
@@ -104,12 +109,14 @@ public class XSKTableParser implements XSKDataStructureParser<XSKDataStructureHD
     Gson gson = new Gson();
 
     XSKHDBTABLEDefinitionModel hdbtableDefinitionModel = gson.fromJson(parsedResult, XSKHDBTABLEDefinitionModel.class);
+    String artefactName = XSKCommonsUtils.getRepositoryBaseObjectName(location);
     try {
       hdbtableDefinitionModel.checkForAllMandatoryFieldsPresence();
     } catch (Exception e) {
       XSKCommonsUtils.logCustomErrors(location, XSKCommonsConstants.PARSER_ERROR, "", "", e.getMessage(),
           XSKCommonsConstants.EXPECTED_FIELDS, XSKCommonsConstants.HDB_TABLE_PARSER, XSKCommonsConstants.MODULE_PARSERS,
           XSKCommonsConstants.SOURCE_PUBLISH_REQUEST, XSKCommonsConstants.PROGRAM_XSK);
+      dataStructuresSynchronizer.applyArtefactState(artefactName,location,TABLE_ARTEFACT, ArtefactState.FAILED_CREATE, e.getMessage());
       throw new XSKHDBTableMissingPropertyException(
           String.format("Wrong format of table definition: [%s]. [%s]", location, e.getMessage()));
     }
@@ -141,6 +148,7 @@ public class XSKTableParser implements XSKDataStructureParser<XSKDataStructureHD
         XSKCommonsUtils.logCustomErrors(location, XSKCommonsConstants.PARSER_ERROR, "", "", errMsg,
             "", XSKCommonsConstants.HDB_TABLE_PARSER,XSKCommonsConstants.MODULE_PARSERS,
             XSKCommonsConstants.SOURCE_PUBLISH_REQUEST, XSKCommonsConstants.PROGRAM_XSK);
+        dataStructuresSynchronizer.applyArtefactState(artefactName,location,TABLE_ARTEFACT, ArtefactState.FAILED_CREATE, errMsg);
         throw new IllegalStateException(errMsg);
       }
     });
@@ -200,12 +208,14 @@ public class XSKTableParser implements XSKDataStructureParser<XSKDataStructureHD
   }
 
   private void validateIndex(XSKHDBTABLEDefinitionModel hdbtableDefinitionModel, String location, XSKHDBTABLEIndexesModel index) {
+    String artefactName = XSKCommonsUtils.getRepositoryBaseObjectName(location);
     try {
       index.checkForAllIndexMandatoryFieldsPresence();
     } catch (Exception e) {
       XSKCommonsUtils.logCustomErrors(location, XSKCommonsConstants.PARSER_ERROR, "", "", e.getMessage(),
           XSKCommonsConstants.EXPECTED_FIELDS, XSKCommonsConstants.HDB_TABLE_PARSER, XSKCommonsConstants.MODULE_PARSERS,
           XSKCommonsConstants.SOURCE_PUBLISH_REQUEST, XSKCommonsConstants.PROGRAM_XSK);
+      dataStructuresSynchronizer.applyArtefactState(artefactName,location,TABLE_ARTEFACT, ArtefactState.FAILED_CREATE, e.getMessage());
       throw new XSKHDBTableMissingPropertyException(
           String.format("Wrong format of table definition: [%s]. [%s]", location, e.getMessage()));
     }
@@ -218,6 +228,7 @@ public class XSKTableParser implements XSKDataStructureParser<XSKDataStructureHD
         XSKCommonsUtils.logCustomErrors(location, XSKCommonsConstants.PARSER_ERROR, "", "", errMsg,
             "", XSKCommonsConstants.HDB_TABLE_PARSER, XSKCommonsConstants.MODULE_PARSERS,
             XSKCommonsConstants.SOURCE_PUBLISH_REQUEST, XSKCommonsConstants.PROGRAM_XSK);
+        dataStructuresSynchronizer.applyArtefactState(artefactName,location,TABLE_ARTEFACT, ArtefactState.FAILED_CREATE, errMsg);
         throw new IllegalStateException(errMsg);
       }
     });

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbview/XSKViewParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbview/XSKViewParser.java
@@ -14,10 +14,12 @@ package com.sap.xsk.hdb.ds.parser.hdbview;
 import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
+import com.sap.xsk.hdb.ds.artefacts.HDBViewSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureDependencyModel;
 import com.sap.xsk.hdb.ds.model.hdbview.XSKDataStructureHDBViewModel;
 import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
+import com.sap.xsk.hdb.ds.synchronizer.XSKDataStructuresSynchronizer;
 import com.sap.xsk.parser.hdbview.core.HdbviewLexer;
 import com.sap.xsk.parser.hdbview.core.HdbviewParser;
 import com.sap.xsk.parser.hdbview.custom.XSKHDBVIEWCoreListener;
@@ -35,12 +37,15 @@ import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class XSKViewParser implements XSKDataStructureParser<XSKDataStructureHDBViewModel> {
 
   private static final Logger logger = LoggerFactory.getLogger(XSKViewParser.class);
+  private static final HDBViewSynchronizationArtefactType VIEW_ARTEFACT = new HDBViewSynchronizationArtefactType();
+  private static final XSKDataStructuresSynchronizer dataStructuresSynchronizer = new XSKDataStructuresSynchronizer();
 
   @Override
   public XSKDataStructureHDBViewModel parse(String location, String content)
@@ -99,6 +104,7 @@ public class XSKViewParser implements XSKDataStructureParser<XSKDataStructureHDB
       XSKCommonsUtils.logCustomErrors(location, XSKCommonsConstants.PARSER_ERROR, "", "", e.getMessage(),
           XSKCommonsConstants.EXPECTED_FIELDS, XSKCommonsConstants.HDB_VIEW_PARSER,XSKCommonsConstants.MODULE_PARSERS,
           XSKCommonsConstants.SOURCE_PUBLISH_REQUEST, XSKCommonsConstants.PROGRAM_XSK);
+      dataStructuresSynchronizer.applyArtefactState(XSKCommonsUtils.getRepositoryBaseObjectName(location),location, VIEW_ARTEFACT, ArtefactState.FAILED_CREATE, e.getMessage());
       throw new XSKDataStructuresException(String.format("Wrong format of HDB View: [%s] during parsing. [%s]", location, e.getMessage()));
     }
     hdbViewModel.setQuery(antlr4Model.getQuery());

--- a/modules/parsers/parser-hdbdd/src/main/java/com/sap/xsk/parser/hdbdd/custom/ReferenceResolvingListener.java
+++ b/modules/parsers/parser-hdbdd/src/main/java/com/sap/xsk/parser/hdbdd/custom/ReferenceResolvingListener.java
@@ -141,12 +141,6 @@ public class ReferenceResolvingListener extends CdsBaseListener {
     String refFullPath = entityName + "." + reference;
     Symbol resolvedSymbol = resolveReferenceChain(refFullPath, associationSymbol, new HashSet<>(Arrays.asList(associationSymbol)));
 
-    EntityElementSymbol entityElement = new EntityElementSymbol((EntityElementSymbol) resolvedSymbol);
-
-    if (ctx.alias != null) {
-      entityElement.setAlias(ctx.alias.getText());
-    }
-
     if (resolvedSymbol == null) {
       throw new CDSRuntimeException(String.format(
           "Error at line: %s. No such field found in entity: %s.",
@@ -155,6 +149,11 @@ public class ReferenceResolvingListener extends CdsBaseListener {
       throw new CDSRuntimeException(String.format(
           "Error at line: %s. Only an entity element could be referenced as a foreign key.",
           resolvedSymbol.getIdToken().getLine()));
+    }
+
+    EntityElementSymbol entityElement = new EntityElementSymbol((EntityElementSymbol) resolvedSymbol);
+    if (ctx.alias != null) {
+      entityElement.setAlias(ctx.alias.getText());
     }
 
     associationSymbol.addForeignKey(entityElement);


### PR DESCRIPTION
Closes sap/fundamental#

1. Keeping synchronization state when parsing of artefacts fails, by covering the following artefacts:

- .hdbdd --> each entity in the hdbdd file
-  .hdbprocedure
-  .hdbschema
-  .hdbsequence
-  .hdbsynonym
-  .hdbtable
-  .hdbtablefunction
-  .hdbview

2. Fixing some "Null Pointer Exceptions" in case of wrong artefacts' definitions, which popped up during testing


