### PR TITLE
Fix issue with outbound POST request with string body

### DIFF
--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/http/http.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/http/http.js
@@ -202,7 +202,10 @@ exports.Client = function () {
 
   function executeRequest(url, requestMethod, options, requestBody) {
     if (requestBody) {
-      options.text = JSON.stringify(requestBody);
+      if(typeof requestBody === 'string' || requestBody instanceof String)
+        options.text = requestBody;
+      else
+        options.text = JSON.stringify(requestBody);
     }
 
     switch (requestMethod) {


### PR DESCRIPTION
Fix for #968 

Changelog:
- http.js -> do not convert to JSON outbound request body object of type String 

