### PR TITLE
fix: use https when cloning dirigiblelabs modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
 		<profile.content.phase>none</profile.content.phase>
 
 		<content.scm.url>https://github.com/dirigiblelabs/${content.repository.name}</content.scm.url>
-		<content.scm.connection>scm:git:git://github.com/dirigiblelabs/${content.repository.name}.git</content.scm.connection>
+		<content.scm.connection>scm:git:https://github.com/dirigiblelabs/${content.repository.name}.git</content.scm.connection>
 		<content.scm.developerConnection>scm:git:https://github.com/dirigiblelabs/${content.repository.name}</content.scm.developerConnection>
 		<content.repository.branch>main</content.repository.branch>
 


### PR DESCRIPTION
As stated in this [Github blog post](https://github.blog/2021-09-01-improving-git-protocol-security-github/#how-do-i-prepare), we should use `https` or a secured `ssh` connection. This PR modifies the maven scm plugin config to use `https`.