### PR TITLE
Changes catalina process to run under unprivileged user

### DIFF
--- a/releng/buildpacks/xsk-cf/Dockerfile
+++ b/releng/buildpacks/xsk-cf/Dockerfile
@@ -1,6 +1,8 @@
 ARG XSK_VERSION=latest
 FROM dirigiblelabs/xsk-cf:$XSK_VERSION as base
 
+USER root
+
 ENV CNB_USER_ID=1000
 ENV CNB_GROUP_ID=1000
 ENV CNB_STACK_ID="com.sap.kneo.xsk"

--- a/releng/buildpacks/xsk-kyma/Dockerfile
+++ b/releng/buildpacks/xsk-kyma/Dockerfile
@@ -1,6 +1,8 @@
 ARG XSK_VERSION=latest
 FROM dirigiblelabs/xsk-kyma:$XSK_VERSION as base
 
+USER root
+
 ENV CNB_USER_ID=1000
 ENV CNB_GROUP_ID=1000
 ENV CNB_STACK_ID="com.sap.kneo.xsk"

--- a/releng/buildpacks/xsk/Dockerfile
+++ b/releng/buildpacks/xsk/Dockerfile
@@ -1,6 +1,8 @@
 ARG XSK_VERSION=latest
 FROM dirigiblelabs/xsk:$XSK_VERSION as base
 
+USER root
+
 ENV CNB_USER_ID=1000
 ENV CNB_GROUP_ID=1000
 ENV CNB_STACK_ID="com.sap.kneo.xsk"

--- a/releng/developer/Dockerfile
+++ b/releng/developer/Dockerfile
@@ -70,4 +70,8 @@ ENV DIRIGBLE_JAVASCRIPT_GRAALVM_DEBUGGER_PORT=0.0.0.0:8081
 
 EXPOSE 8080 8081 8000
 
+RUN useradd -rm -d $CATALINA_HOME -s /bin/bash -u 1001 dirigible && chown -R dirigible:dirigible $CATALINA_HOME
+
+USER dirigible
+
 CMD ["catalina.sh", "jpda", "run"]

--- a/releng/sap-cf/Dockerfile
+++ b/releng/sap-cf/Dockerfile
@@ -50,4 +50,8 @@ ENV DIRIGBLE_JAVASCRIPT_GRAALVM_DEBUGGER_PORT=0.0.0.0:8081
 
 EXPOSE 8080
 
+RUN useradd -rm -d $CATALINA_HOME -s /bin/bash -u 1001 dirigible && chown -R dirigible:dirigible $CATALINA_HOME
+
+USER dirigible
+
 CMD ["catalina.sh", "jpda", "run"]

--- a/releng/sap-kyma/Dockerfile
+++ b/releng/sap-kyma/Dockerfile
@@ -50,4 +50,8 @@ ENV DIRIGBLE_JAVASCRIPT_GRAALVM_DEBUGGER_PORT=0.0.0.0:8081
 
 EXPOSE 8080
 
+RUN useradd -rm -d $CATALINA_HOME -s /bin/bash -u 1001 dirigible && chown -R dirigible:dirigible $CATALINA_HOME
+
+USER dirigible
+
 CMD ["catalina.sh", "jpda", "run"]

--- a/releng/server/Dockerfile
+++ b/releng/server/Dockerfile
@@ -58,4 +58,8 @@ ENV DIRIGBLE_JAVASCRIPT_GRAALVM_DEBUGGER_PORT=0.0.0.0:8081
 
 EXPOSE 8080 8081 8000
 
+RUN useradd -rm -d $CATALINA_HOME -s /bin/bash -u 1001 dirigible && chown -R dirigible:dirigible $CATALINA_HOME
+
+USER dirigible
+
 CMD ["catalina.sh", "jpda", "run"]


### PR DESCRIPTION
By default, tomcat image runs java process as `root`, which may pose potential risks for container escape.

Switching to unprivileged user adds additional barrier so attacker will have to implement privilege escalation attack first as typically container escape attack requires root level access to be gained first.

#### Test

* tested locally by starting xsk container on standalone system. Seems working, yet requires verification.

#### Changelog

**New**

* adduser and chown added to dockerfiles, as well as USER command.

**Changed**

* Dockerfiles were missing ending newline, that's cosmetic change.
