### PR TITLE
Revert back changes for tomcat to run under unprivileged user 

### DIFF
--- a/releng/buildpacks/xsk-cf/Dockerfile
+++ b/releng/buildpacks/xsk-cf/Dockerfile
@@ -1,8 +1,6 @@
 ARG XSK_VERSION=latest
 FROM dirigiblelabs/xsk-cf:$XSK_VERSION as base
 
-USER root
-
 ENV CNB_USER_ID=1000
 ENV CNB_GROUP_ID=1000
 ENV CNB_STACK_ID="com.sap.kneo.xsk"

--- a/releng/buildpacks/xsk-kyma/Dockerfile
+++ b/releng/buildpacks/xsk-kyma/Dockerfile
@@ -1,8 +1,6 @@
 ARG XSK_VERSION=latest
 FROM dirigiblelabs/xsk-kyma:$XSK_VERSION as base
 
-USER root
-
 ENV CNB_USER_ID=1000
 ENV CNB_GROUP_ID=1000
 ENV CNB_STACK_ID="com.sap.kneo.xsk"

--- a/releng/buildpacks/xsk/Dockerfile
+++ b/releng/buildpacks/xsk/Dockerfile
@@ -1,8 +1,6 @@
 ARG XSK_VERSION=latest
 FROM dirigiblelabs/xsk:$XSK_VERSION as base
 
-USER root
-
 ENV CNB_USER_ID=1000
 ENV CNB_GROUP_ID=1000
 ENV CNB_STACK_ID="com.sap.kneo.xsk"

--- a/releng/developer/Dockerfile
+++ b/releng/developer/Dockerfile
@@ -70,8 +70,4 @@ ENV DIRIGBLE_JAVASCRIPT_GRAALVM_DEBUGGER_PORT=0.0.0.0:8081
 
 EXPOSE 8080 8081 8000
 
-RUN useradd -rm -d $CATALINA_HOME -s /bin/bash -u 1001 dirigible && chown -R dirigible:dirigible $CATALINA_HOME
-
-USER dirigible
-
 CMD ["catalina.sh", "jpda", "run"]

--- a/releng/sap-cf/Dockerfile
+++ b/releng/sap-cf/Dockerfile
@@ -50,8 +50,4 @@ ENV DIRIGBLE_JAVASCRIPT_GRAALVM_DEBUGGER_PORT=0.0.0.0:8081
 
 EXPOSE 8080
 
-RUN useradd -rm -d $CATALINA_HOME -s /bin/bash -u 1001 dirigible && chown -R dirigible:dirigible $CATALINA_HOME
-
-USER dirigible
-
 CMD ["catalina.sh", "jpda", "run"]

--- a/releng/sap-kyma/Dockerfile
+++ b/releng/sap-kyma/Dockerfile
@@ -50,8 +50,4 @@ ENV DIRIGBLE_JAVASCRIPT_GRAALVM_DEBUGGER_PORT=0.0.0.0:8081
 
 EXPOSE 8080
 
-RUN useradd -rm -d $CATALINA_HOME -s /bin/bash -u 1001 dirigible && chown -R dirigible:dirigible $CATALINA_HOME
-
-USER dirigible
-
 CMD ["catalina.sh", "jpda", "run"]

--- a/releng/server/Dockerfile
+++ b/releng/server/Dockerfile
@@ -58,8 +58,4 @@ ENV DIRIGBLE_JAVASCRIPT_GRAALVM_DEBUGGER_PORT=0.0.0.0:8081
 
 EXPOSE 8080 8081 8000
 
-RUN useradd -rm -d $CATALINA_HOME -s /bin/bash -u 1001 dirigible && chown -R dirigible:dirigible $CATALINA_HOME
-
-USER dirigible
-
 CMD ["catalina.sh", "jpda", "run"]


### PR DESCRIPTION
It turns out that 

* switching to unprivileged user breaks deployment to k8s cluster with existing persistent volumes
* should probably be better implemented with securityContext feature which effectively override USER setting defined with dockerfile (yet, check required)

Thus, rolling it back for now for further investigation and testing.