### PR TITLE
feat: Add synonym generation during migration

### DIFF
--- a/modules/engines/engine-commons/src/main/java/com/sap/xsk/utils/XSKCommonsConstants.java
+++ b/modules/engines/engine-commons/src/main/java/com/sap/xsk/utils/XSKCommonsConstants.java
@@ -60,4 +60,5 @@ public final class XSKCommonsConstants {
     public static final String XSK_ENTITY_PROCESSOR = "XSK Entity";
     public static final String HDI_PROCESSOR = "HDI";
     public static final String HDB_ANALYTIC_PRIVILEGE = "HDB Analytic Privilege";
+    public static final String XSK_REGISTRY_PUBLIC = "/registry/public/";
 }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/api/IXSKDataStructureModel.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/api/IXSKDataStructureModel.java
@@ -72,6 +72,11 @@ public interface IXSKDataStructureModel {
   public static final String FILE_EXTENSION_STRUCTURE = ".hdbstructure";
 
   /**
+   * File extension for *.hdbtabletype files
+   */
+  public static final String FILE_EXTENSION_HDB_TABLE_TYPE = ".hdbtabletype";
+
+  /**
    * Type hdbdd
    */
   public static final String TYPE_HDBDD = "HDBDD";

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/facade/XSKHDBCoreFacade.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/facade/XSKHDBCoreFacade.java
@@ -18,6 +18,7 @@ import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.IXSKEnvironmentVariables;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModel;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureCdsModel;
 import com.sap.xsk.hdb.ds.model.hdbprocedure.XSKDataStructureHDBProcedureModel;
 import com.sap.xsk.hdb.ds.model.hdbschema.XSKDataStructureHDBSchemaModel;
@@ -33,6 +34,7 @@ import com.sap.xsk.hdb.ds.service.XSKDataStructureTopologicalSorter;
 import com.sap.xsk.hdb.ds.service.manager.IXSKDataStructureManager;
 import com.sap.xsk.hdb.ds.service.parser.IXSKCoreParserService;
 import com.sap.xsk.hdb.ds.service.parser.XSKCoreParserService;
+import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKHDBUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -88,7 +90,7 @@ public class XSKHDBCoreFacade implements IXSKHDBCoreFacade {
     return buff.toString();
   }
 
-  public XSKDataStructureModel parseDataStructureModel(String fileName, String path, String content)
+  public XSKDataStructureModel parseDataStructureModel(String fileName, String path, String content, String workspace)
       throws SynchronizationException {
     String[] splitResourceName = fileName.split("\\.");
     String resourceExtension = "." + splitResourceName[splitResourceName.length - 1];
@@ -101,7 +103,9 @@ public class XSKHDBCoreFacade implements IXSKHDBCoreFacade {
         return null;
       }
 
-      dataStructureModel = xskCoreParserService.parseDataStructure(resourceExtension, registryPath, contentAsString);
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(resourceExtension, registryPath, contentAsString, workspace);
+      dataStructureModel = xskCoreParserService.parseDataStructure(parametersModel);
 
       if (dataStructureModel == null) {
         return null;
@@ -125,7 +129,7 @@ public class XSKHDBCoreFacade implements IXSKHDBCoreFacade {
   }
 
   public XSKDataStructureModel parseDataStructureModel(IResource resource) throws SynchronizationException {
-    return this.parseDataStructureModel(resource.getName(), getRegistryPath(resource), getContent(resource));
+    return this.parseDataStructureModel(resource.getName(), getRegistryPath(resource), getContent(resource), XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
   }
 
   @Override

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/model/XSKDataStructureModelFactory.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/model/XSKDataStructureModelFactory.java
@@ -26,6 +26,7 @@ import com.sap.xsk.hdb.ds.parser.hdbsynonym.XSKSynonymParser;
 import com.sap.xsk.hdb.ds.parser.hdbtable.XSKTableParser;
 import com.sap.xsk.hdb.ds.parser.hdbtabletype.XSKTableTypeParser;
 import com.sap.xsk.hdb.ds.parser.hdbview.XSKViewParser;
+import com.sap.xsk.utils.XSKCommonsConstants;
 
 //import com.sap.xsk.models.hdbdd.HdbDDStandaloneSetup;
 
@@ -53,7 +54,9 @@ public class XSKDataStructureModelFactory {
    */
   public static XSKDataStructureHDBTableModel parseTable(String location, String content) throws Exception {
     XSKTableParser parser = new XSKTableParser();
-    XSKDataStructureHDBTableModel result = parser.parse(location, content);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, null);
+    XSKDataStructureHDBTableModel result = parser.parse(parametersModel);
     return result;
   }
 
@@ -75,13 +78,17 @@ public class XSKDataStructureModelFactory {
    */
   public static XSKDataStructureHDBViewModel parseView(String location, String content) throws Exception {
     XSKViewParser parser = new XSKViewParser();
-    XSKDataStructureHDBViewModel result = parser.parse(location, content);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, null);
+    XSKDataStructureHDBViewModel result = parser.parse(parametersModel);
     return result;
   }
 
   public static XSKDataStructureModel parseHdbdd(String location, String content) throws Exception {
     XSKHdbddParser parser = new XSKHdbddParser();
-    XSKDataStructureModel result = parser.parse(location, content);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
+    XSKDataStructureModel result = parser.parse(parametersModel);
     return result;
   }
 
@@ -103,7 +110,9 @@ public class XSKDataStructureModelFactory {
    */
   public static XSKDataStructureHDBSynonymModel parseSynonym(String location, String content) throws Exception {
     XSKSynonymParser parser = new XSKSynonymParser();
-    XSKDataStructureHDBSynonymModel result = parser.parse(location, content);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, null);
+    XSKDataStructureHDBSynonymModel result = parser.parse(parametersModel);
     return result;
   }
 
@@ -142,7 +151,9 @@ public class XSKDataStructureModelFactory {
    */
   public static XSKDataStructureHDBSchemaModel parseSchema(String location, String content) throws Exception {
     XSKSchemaParser parser = new XSKSchemaParser();
-    XSKDataStructureHDBSchemaModel result = parser.parse(location, content);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, null);
+    XSKDataStructureHDBSchemaModel result = parser.parse(parametersModel);
     return result;
   }
 
@@ -196,7 +207,9 @@ public class XSKDataStructureModelFactory {
    */
   public static XSKDataStructureHDBTableTypeModel parseTableType(String location, String content) throws Exception {
     XSKTableTypeParser parser = new XSKTableTypeParser();
-    XSKDataStructureHDBTableTypeModel result = parser.parse(location, content);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, null);
+    XSKDataStructureHDBTableTypeModel result = parser.parse(parametersModel);
     return result;
   }
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/model/XSKDataStructureParametersModel.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/model/XSKDataStructureParametersModel.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and XSK contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and XSK contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.xsk.hdb.ds.model;
+
+public class XSKDataStructureParametersModel {
+
+  private String type;
+  private String location;
+  private String content;
+  private String workspacePath;
+
+  public XSKDataStructureParametersModel() {
+  }
+
+  public XSKDataStructureParametersModel(String type, String location, String content, String workspacePath) {
+    this.type = type;
+    this.location = location;
+    this.content = content;
+    this.workspacePath = workspacePath;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String getLocation() {
+    return location;
+  }
+
+  public void setLocation(String location) {
+    this.location = location;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public void setContent(String content) {
+    this.content = content;
+  }
+
+  public String getWorkspacePath() {
+    return workspacePath;
+  }
+
+  public void setWorkspacePath(String workspacePath) {
+    this.workspacePath = workspacePath;
+  }
+}

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/module/XSKHDBModule.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/module/XSKHDBModule.java
@@ -102,6 +102,7 @@ public class XSKHDBModule extends AbstractDirigibleModule {
     parserServices.put(IXSKDataStructureModel.FILE_EXTENSION_HDBSEQUENCE, new XSKHDBSequenceParser());
     parserServices.put(IXSKDataStructureModel.FILE_EXTENSION_HDBSCALARFUNCTION, new XSKHDBScalarFunctionParser());
     parserServices.put(IXSKDataStructureModel.FILE_EXTENSION_STRUCTURE, new XSKTableTypeParser());
+    parserServices.put(IXSKDataStructureModel.FILE_EXTENSION_HDB_TABLE_TYPE, new XSKTableTypeParser());
 
     parserServices.put(IXSKDataStructureModel.TYPE_HDBDD, new XSKHdbddParser());
     parserServices.put(IXSKDataStructureModel.TYPE_HDB_TABLE, new XSKTableParser());

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/XSKDataStructureParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/XSKDataStructureParser.java
@@ -14,11 +14,12 @@ package com.sap.xsk.hdb.ds.parser;
 import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModel;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import java.io.IOException;
 
 public interface XSKDataStructureParser<T extends XSKDataStructureModel> {
 
-  T parse(String location, String content) throws XSKDataStructuresException, IOException, XSKArtifactParserException;
+  T parse(XSKDataStructureParametersModel parametersModel) throws XSKDataStructuresException, IOException, XSKArtifactParserException;
 
   String getType();
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbdd/XSKHdbddParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbdd/XSKHdbddParser.java
@@ -17,6 +17,7 @@ import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.artefacts.HDBDDEntitySynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModel;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureCdsModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableModel;
 import com.sap.xsk.hdb.ds.model.hdbtabletype.XSKDataStructureHDBTableTypeModel;
@@ -71,9 +72,9 @@ public class XSKHdbddParser implements XSKDataStructureParser {
   private XSKDataStructuresSynchronizer dataStructuresSynchronizer = new XSKDataStructuresSynchronizer();
 
   @Override
-  public XSKDataStructureModel parse(String location, String content) throws XSKDataStructuresException, IOException {
-    for (String fileLocation : this.getFilesToProcess(location)) {
-      IResource loadedResource = this.repository.getResource("/registry/public/" + fileLocation);
+  public XSKDataStructureModel parse(XSKDataStructureParametersModel parametersModel) throws XSKDataStructuresException, IOException {
+    for (String fileLocation : this.getFilesToProcess(parametersModel.getLocation())) {
+      IResource loadedResource = this.repository.getResource(parametersModel.getWorkspacePath() + fileLocation);
       String fileContent = new String(loadedResource.getContent());
       try {
         parseHdbdd(fileLocation, fileContent);
@@ -84,7 +85,7 @@ public class XSKHdbddParser implements XSKDataStructureParser {
       }
     }
 
-    XSKDataStructureCdsModel cdsModel = populateXSKDataStructureCdsModel(location, content);
+    XSKDataStructureCdsModel cdsModel = populateXSKDataStructureCdsModel(parametersModel.getLocation(), parametersModel.getContent());
     this.symbolTable.clearSymbolsByFullName();
     this.symbolTable.clearEntityGraph();
     parsedNodes.clear();

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbprocedure/XSKHDBProcedureParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbprocedure/XSKHDBProcedureParser.java
@@ -13,6 +13,7 @@ package com.sap.xsk.hdb.ds.parser.hdbprocedure;
 
 import java.sql.Timestamp;
 
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.utils.XSKHDBUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.eclipse.dirigible.api.v3.security.UserFacade;
@@ -25,15 +26,15 @@ import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
 public class XSKHDBProcedureParser implements XSKDataStructureParser {
 
   @Override
-  public XSKDataStructureHDBProcedureModel parse(String location, String content) throws XSKDataStructuresException {
+  public XSKDataStructureHDBProcedureModel parse(XSKDataStructureParametersModel parametersModel) throws XSKDataStructuresException {
     XSKDataStructureHDBProcedureModel hdbProcedure = new XSKDataStructureHDBProcedureModel();
-    hdbProcedure.setName(XSKHDBUtils.extractProcedureNameFromContent(content, location));
-    hdbProcedure.setLocation(location);
+    hdbProcedure.setName(XSKHDBUtils.extractProcedureNameFromContent(parametersModel.getContent(), parametersModel.getLocation()));
+    hdbProcedure.setLocation(parametersModel.getLocation());
     hdbProcedure.setType(getType());
-    hdbProcedure.setHash(DigestUtils.md5Hex(content));
+    hdbProcedure.setHash(DigestUtils.md5Hex(parametersModel.getContent()));
     hdbProcedure.setCreatedBy(UserFacade.getName());
     hdbProcedure.setCreatedAt(new Timestamp(new java.util.Date().getTime()));
-    hdbProcedure.setContent(content);
+    hdbProcedure.setContent(parametersModel.getContent());
     return hdbProcedure;
   }
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbscalarfunction/XSKHDBScalarFunctionParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbscalarfunction/XSKHDBScalarFunctionParser.java
@@ -13,6 +13,7 @@ package com.sap.xsk.hdb.ds.parser.hdbscalarfunction;
 
 import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbtablefunction.XSKDataStructureHDBTableFunctionModel;
 import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
 import com.sap.xsk.utils.XSKCommonsConstants;
@@ -24,15 +25,16 @@ import java.sql.Timestamp;
 public class XSKHDBScalarFunctionParser implements XSKDataStructureParser<XSKDataStructureHDBTableFunctionModel> {
 
   @Override
-  public XSKDataStructureHDBTableFunctionModel parse(String location, String content) throws XSKDataStructuresException {
+  public XSKDataStructureHDBTableFunctionModel parse(XSKDataStructureParametersModel parametersModel) throws XSKDataStructuresException {
     XSKDataStructureHDBTableFunctionModel hdbTableFunction = new XSKDataStructureHDBTableFunctionModel();
-    hdbTableFunction.setName(XSKHDBUtils.extractTableFunctionNameFromContent(content, location, XSKCommonsConstants.HDB_SCALAR_FUNCTION_PARSER));
-    hdbTableFunction.setLocation(location);
+    hdbTableFunction.setName(XSKHDBUtils.extractTableFunctionNameFromContent(parametersModel.getContent(), parametersModel.getLocation(),
+        XSKCommonsConstants.HDB_SCALAR_FUNCTION_PARSER));
+    hdbTableFunction.setLocation(parametersModel.getLocation());
     hdbTableFunction.setType(getType());
-    hdbTableFunction.setHash(DigestUtils.md5Hex(content));
+    hdbTableFunction.setHash(DigestUtils.md5Hex(parametersModel.getContent()));
     hdbTableFunction.setCreatedBy(UserFacade.getName());
     hdbTableFunction.setCreatedAt(new Timestamp(new java.util.Date().getTime()));
-    hdbTableFunction.setContent(content);
+    hdbTableFunction.setContent(parametersModel.getContent());
     return hdbTableFunction;
   }
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbschema/XSKSchemaParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbschema/XSKSchemaParser.java
@@ -16,6 +16,7 @@ import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.artefacts.HDBSchemaSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbschema.XSKDataStructureHDBSchemaModel;
 import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
 import com.sap.xsk.hdb.ds.synchronizer.XSKDataStructuresSynchronizer;
@@ -54,13 +55,13 @@ public class XSKSchemaParser implements XSKDataStructureParser<XSKDataStructureH
   }
 
   @Override
-  public XSKDataStructureHDBSchemaModel parse(String location, String content)
+  public XSKDataStructureHDBSchemaModel parse(XSKDataStructureParametersModel parametersModel)
       throws XSKDataStructuresException, IOException, XSKArtifactParserException {
     XSKDataStructureHDBSchemaModel hdbSchemaModel = new XSKDataStructureHDBSchemaModel();
-    XSKHDBUtils.populateXSKDataStructureModel(location, content, hdbSchemaModel, IXSKDataStructureModel.TYPE_HDB_SCHEMA,
-        XSKDBContentType.XS_CLASSIC);
+    XSKHDBUtils.populateXSKDataStructureModel(parametersModel.getLocation(), parametersModel.getContent(), hdbSchemaModel,
+        IXSKDataStructureModel.TYPE_HDB_SCHEMA, XSKDBContentType.XS_CLASSIC);
 
-    ByteArrayInputStream is = new ByteArrayInputStream(content.getBytes());
+    ByteArrayInputStream is = new ByteArrayInputStream(parametersModel.getContent().getBytes());
     ANTLRInputStream inputStream = new ANTLRInputStream(is);
     HdbschemaLexer lexer = new HdbschemaLexer(inputStream);
     XSKHDBSCHEMASyntaxErrorListener lexerErrorListener = new XSKHDBSCHEMASyntaxErrorListener();
@@ -76,13 +77,17 @@ public class XSKSchemaParser implements XSKDataStructureParser<XSKDataStructureH
 
     ParseTree parseTree = hdbschemaParser.hdbschemaDefinition();
     if(parserErrorListener.getErrors().size() !=0 ){
-      dataStructuresSynchronizer.applyArtefactState(XSKCommonsUtils.getRepositoryBaseObjectName(location),location,SCHEMA_ARTEFACT, ArtefactState.FAILED_CREATE, parserErrorListener.getErrors().get(0).getMsg());
+      dataStructuresSynchronizer.applyArtefactState(XSKCommonsUtils.getRepositoryBaseObjectName(parametersModel.getLocation()),
+          parametersModel.getLocation(),SCHEMA_ARTEFACT, ArtefactState.FAILED_CREATE, parserErrorListener.getErrors().get(0).getMsg());
     }
     if(lexerErrorListener.getErrors().size() != 0) {
-      dataStructuresSynchronizer.applyArtefactState(XSKCommonsUtils.getRepositoryBaseObjectName(location),location,SCHEMA_ARTEFACT, ArtefactState.FAILED_CREATE, lexerErrorListener.getErrors().get(0).getMsg());
+      dataStructuresSynchronizer.applyArtefactState(XSKCommonsUtils.getRepositoryBaseObjectName(parametersModel.getLocation()),
+          parametersModel.getLocation(),SCHEMA_ARTEFACT, ArtefactState.FAILED_CREATE, lexerErrorListener.getErrors().get(0).getMsg());
     }
-    XSKCommonsUtils.logParserErrors(parserErrorListener.getErrors(), XSKCommonsConstants.PARSER_ERROR, location, XSKCommonsConstants.HDB_SCHEMA_PARSER);
-    XSKCommonsUtils.logParserErrors(lexerErrorListener.getErrors(), XSKCommonsConstants.LEXER_ERROR, location, XSKCommonsConstants.HDB_SCHEMA_PARSER);
+    XSKCommonsUtils.logParserErrors(parserErrorListener.getErrors(), XSKCommonsConstants.PARSER_ERROR, parametersModel.getLocation(),
+        XSKCommonsConstants.HDB_SCHEMA_PARSER);
+    XSKCommonsUtils.logParserErrors(lexerErrorListener.getErrors(), XSKCommonsConstants.LEXER_ERROR, parametersModel.getLocation(),
+        XSKCommonsConstants.HDB_SCHEMA_PARSER);
 
     XSKHDBSCHEMACoreListener XSKHDBSCHEMACoreListener = new XSKHDBSCHEMACoreListener();
     ParseTreeWalker parseTreeWalker = new ParseTreeWalker();

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbsequence/XSKHDBSequenceParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbsequence/XSKHDBSequenceParser.java
@@ -19,6 +19,7 @@ import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModel;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbsequence.XSKDataStructureHDBSequenceModel;
 import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
 import com.sap.xsk.parser.hdbsequence.core.HdbsequenceBaseVisitor;
@@ -48,14 +49,14 @@ public class XSKHDBSequenceParser implements XSKDataStructureParser {
   private static final Logger logger = LoggerFactory.getLogger(XSKHDBSequenceParser.class);
 
   @Override
-  public XSKDataStructureModel parse(String location, String content)
+  public XSKDataStructureModel parse(XSKDataStructureParametersModel parametersModel)
       throws XSKDataStructuresException, IOException, XSKArtifactParserException {
     Pattern pattern = Pattern.compile("^(\\t\\n)*(\\s)*SEQUENCE", Pattern.CASE_INSENSITIVE);
-    Matcher matcher = pattern.matcher(content.trim().toUpperCase(Locale.ROOT));
+    Matcher matcher = pattern.matcher(parametersModel.getContent().trim().toUpperCase(Locale.ROOT));
     boolean matchFound = matcher.find();
     return (matchFound)
-        ? parseHanaXSAdvancedContent(location, content)
-        : parseHanaXSClassicContent(location, content);
+        ? parseHanaXSAdvancedContent(parametersModel.getLocation(), parametersModel.getContent())
+        : parseHanaXSClassicContent(parametersModel.getLocation(), parametersModel.getContent());
   }
 
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbsynonym/XSKSynonymParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbsynonym/XSKSynonymParser.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import com.sap.xsk.hdb.ds.artefacts.HDBSynonymSynchronizationArtefactType;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.synchronizer.XSKDataStructuresSynchronizer;
 import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
@@ -43,13 +44,14 @@ public class XSKSynonymParser implements XSKDataStructureParser {
   private static final XSKDataStructuresSynchronizer dataStructuresSynchronizer = new XSKDataStructuresSynchronizer();
 
   @Override
-  public XSKDataStructureHDBSynonymModel parse(String location, String content) throws XSKDataStructuresException, IOException {
+  public XSKDataStructureHDBSynonymModel parse(XSKDataStructureParametersModel parametersModel) throws XSKDataStructuresException, IOException {
     XSKDataStructureHDBSynonymModel hdbSynonymModel = new XSKDataStructureHDBSynonymModel();
-    XSKHDBUtils.populateXSKDataStructureModel(location, content, hdbSynonymModel, IXSKDataStructureModel.TYPE_HDB_SYNONYM, XSKDBContentType.XS_CLASSIC);
+    XSKHDBUtils.populateXSKDataStructureModel(parametersModel.getLocation(), parametersModel.getContent(), hdbSynonymModel,
+        IXSKDataStructureModel.TYPE_HDB_SYNONYM, XSKDBContentType.XS_CLASSIC);
 
     Gson gson = new Gson();
     JsonParser jsonParser = new JsonParser();
-    JsonObject jsonObject = jsonParser.parse(content).getAsJsonObject();
+    JsonObject jsonObject = jsonParser.parse(parametersModel.getContent()).getAsJsonObject();
 
     Map<String, XSKHDBSYNONYMDefinitionModel> synonymDefinitions = new HashMap<>();
     for (Entry<String, JsonElement> entry : jsonObject.entrySet()) {
@@ -62,11 +64,12 @@ public class XSKSynonymParser implements XSKDataStructureParser {
         //aligned with HANA XS Classic, where the synonym name must match the artifact name and multiple synonym definitions are not supported
         //synonymDefinitions.put(hdbSynonymModel.getName(), definitionModel);
       } catch (XSKHDBSYNONYMMissingPropertyException exception) {
-        XSKCommonsUtils.logCustomErrors(location, XSKCommonsConstants.PARSER_ERROR, "", "",
+        XSKCommonsUtils.logCustomErrors(parametersModel.getLocation(), XSKCommonsConstants.PARSER_ERROR, "", "",
             String.format("Missing mandatory field for synonym %s!", entry.getKey()), XSKCommonsConstants.EXPECTED_FIELDS,
             XSKCommonsConstants.HDB_SYNONYM_PARSER,XSKCommonsConstants.MODULE_PARSERS,XSKCommonsConstants.SOURCE_PUBLISH_REQUEST,
             XSKCommonsConstants.PROGRAM_XSK);
-        dataStructuresSynchronizer.applyArtefactState(entry.getKey(),location,SYNONYM_ARTEFACT, ArtefactState.FAILED_CREATE, exception.getMessage());
+        dataStructuresSynchronizer.applyArtefactState(entry.getKey(),parametersModel.getLocation(),SYNONYM_ARTEFACT,
+            ArtefactState.FAILED_CREATE, exception.getMessage());
       }
     }
     hdbSynonymModel.setSynonymDefinitions(synonymDefinitions);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbtable/XSKTableParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbtable/XSKTableParser.java
@@ -18,6 +18,7 @@ import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.artefacts.HDBTableSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintPrimaryKeyModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintUniqueModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintsModel;
@@ -71,14 +72,14 @@ public class XSKTableParser implements XSKDataStructureParser<XSKDataStructureHD
   }
 
   @Override
-  public XSKDataStructureHDBTableModel parse(String location, String content)
+  public XSKDataStructureHDBTableModel parse(XSKDataStructureParametersModel parametersModel)
       throws XSKDataStructuresException, IOException, XSKArtifactParserException {
     Pattern pattern = Pattern.compile("^(\\t\\n)*(\\s)*(COLUMN)(\\t\\n)*(\\s)*(TABLE)", Pattern.CASE_INSENSITIVE);
-    Matcher matcher = pattern.matcher(content.trim().toUpperCase(Locale.ROOT));
+    Matcher matcher = pattern.matcher(parametersModel.getContent().trim().toUpperCase(Locale.ROOT));
     boolean matchFound = matcher.find();
     return (matchFound)
-        ? parseHanaXSAdvancedContent(location, content)
-        : parseHanaXSClassicContent(location, content);
+        ? parseHanaXSAdvancedContent(parametersModel.getLocation(), parametersModel.getContent())
+        : parseHanaXSClassicContent(parametersModel.getLocation(), parametersModel.getContent());
   }
 
   private XSKDataStructureHDBTableModel parseHanaXSClassicContent(String location, String content)

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbtablefunction/XSKHDBTableFunctionParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbtablefunction/XSKHDBTableFunctionParser.java
@@ -13,6 +13,7 @@ package com.sap.xsk.hdb.ds.parser.hdbtablefunction;
 
 import java.sql.Timestamp;
 
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKHDBUtils;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -26,15 +27,16 @@ import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
 public class XSKHDBTableFunctionParser implements XSKDataStructureParser<XSKDataStructureHDBTableFunctionModel> {
 
   @Override
-  public XSKDataStructureHDBTableFunctionModel parse(String location, String content) throws XSKDataStructuresException {
+  public XSKDataStructureHDBTableFunctionModel parse(XSKDataStructureParametersModel parametersModel) throws XSKDataStructuresException {
     XSKDataStructureHDBTableFunctionModel hdbTableFunction = new XSKDataStructureHDBTableFunctionModel();
-    hdbTableFunction.setName(XSKHDBUtils.extractTableFunctionNameFromContent(content, location, XSKCommonsConstants.HDB_TABLE_FUNCTION_PARSER));
-    hdbTableFunction.setLocation(location);
+    hdbTableFunction.setName(XSKHDBUtils.extractTableFunctionNameFromContent(parametersModel.getContent(), parametersModel.getLocation(),
+        XSKCommonsConstants.HDB_TABLE_FUNCTION_PARSER));
+    hdbTableFunction.setLocation(parametersModel.getLocation());
     hdbTableFunction.setType(getType());
-    hdbTableFunction.setHash(DigestUtils.md5Hex(content));
+    hdbTableFunction.setHash(DigestUtils.md5Hex(parametersModel.getContent()));
     hdbTableFunction.setCreatedBy(UserFacade.getName());
     hdbTableFunction.setCreatedAt(new Timestamp(new java.util.Date().getTime()));
-    hdbTableFunction.setContent(content);
+    hdbTableFunction.setContent(parametersModel.getContent());
     return hdbTableFunction;
   }
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbtabletype/XSKTableTypeParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbtabletype/XSKTableTypeParser.java
@@ -17,6 +17,7 @@ import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbtabletype.XSKDataStructureHDBTableTypeModel;
 import com.sap.xsk.hdb.ds.model.hdbtabletype.XSKDataStructureHDBTableTypePrimaryKeyModel;
 import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
@@ -50,14 +51,14 @@ public class XSKTableTypeParser implements XSKDataStructureParser<XSKDataStructu
   private HDBTableDefinitionModelToHDBTableColumnModelTransformer columnModelTransformer = new HDBTableDefinitionModelToHDBTableColumnModelTransformer();
 
   @Override
-  public XSKDataStructureHDBTableTypeModel parse(String location, String content)
+  public XSKDataStructureHDBTableTypeModel parse(XSKDataStructureParametersModel parametersModel)
       throws XSKDataStructuresException, IOException, XSKArtifactParserException {
     Pattern pattern = Pattern.compile("^(\\t\\n)*(\\s)*TYPE", Pattern.CASE_INSENSITIVE);
-    Matcher matcher = pattern.matcher(content.trim().toUpperCase(Locale.ROOT));
+    Matcher matcher = pattern.matcher(parametersModel.getContent().trim().toUpperCase(Locale.ROOT));
     boolean matchFound = matcher.find();
     return (matchFound)
-        ? parseHanaXSAdvancedContent(location, content)
-        : parseHanaXSClassicContent(location, content);
+        ? parseHanaXSAdvancedContent(parametersModel.getLocation(), parametersModel.getContent())
+        : parseHanaXSClassicContent(parametersModel.getLocation(), parametersModel.getContent());
   }
 
   private XSKDataStructureHDBTableTypeModel parseHanaXSClassicContent(String location, String content)

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbview/XSKViewParser.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/parser/hdbview/XSKViewParser.java
@@ -17,6 +17,7 @@ import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.artefacts.HDBViewSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureDependencyModel;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbview.XSKDataStructureHDBViewModel;
 import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
 import com.sap.xsk.hdb.ds.synchronizer.XSKDataStructuresSynchronizer;
@@ -48,14 +49,14 @@ public class XSKViewParser implements XSKDataStructureParser<XSKDataStructureHDB
   private static final XSKDataStructuresSynchronizer dataStructuresSynchronizer = new XSKDataStructuresSynchronizer();
 
   @Override
-  public XSKDataStructureHDBViewModel parse(String location, String content)
+  public XSKDataStructureHDBViewModel parse(XSKDataStructureParametersModel parametersModel)
       throws XSKDataStructuresException, IOException, XSKArtifactParserException {
     Pattern pattern = Pattern.compile("^(\\t\\n)*(\\s)*VIEW", Pattern.CASE_INSENSITIVE);
-    Matcher matcher = pattern.matcher(content.trim().toUpperCase(Locale.ROOT));
+    Matcher matcher = pattern.matcher(parametersModel.getContent().trim().toUpperCase(Locale.ROOT));
     boolean matchFound = matcher.find();
     return (matchFound)
-        ? parseHanaXSAdvancedContent(location, content)
-        : parseHanaXSClassicContent(location, content);
+        ? parseHanaXSAdvancedContent(parametersModel.getLocation(), parametersModel.getContent())
+        : parseHanaXSClassicContent(parametersModel.getLocation(), parametersModel.getContent());
   }
 
   private XSKDataStructureHDBViewModel parseHanaXSAdvancedContent(String location, String content) {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/service/parser/IXSKCoreParserService.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/service/parser/IXSKCoreParserService.java
@@ -14,11 +14,12 @@ package com.sap.xsk.hdb.ds.service.parser;
 import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModel;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import java.io.IOException;
 
 public interface IXSKCoreParserService {
 
-  XSKDataStructureModel parseDataStructure(String type, String location, String content)
+  XSKDataStructureModel parseDataStructure(XSKDataStructureParametersModel parametersModel)
       throws XSKDataStructuresException, IOException, XSKArtifactParserException;
 
   Class<XSKDataStructureModel> getDataStructureClass(String type);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/service/parser/XSKCoreParserService.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/service/parser/XSKCoreParserService.java
@@ -14,6 +14,7 @@ package com.sap.xsk.hdb.ds.service.parser;
 import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModel;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.module.XSKHDBModule;
 import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
 import java.io.IOException;
@@ -24,11 +25,11 @@ public class XSKCoreParserService implements IXSKCoreParserService {
   private Map<String, XSKDataStructureParser> parserServices = XSKHDBModule.getParserServices();
 
   @Override
-  public XSKDataStructureModel parseDataStructure(String type, String location, String content)
+  public XSKDataStructureModel parseDataStructure(XSKDataStructureParametersModel parametersModel)
       throws XSKDataStructuresException, IOException, XSKArtifactParserException {
 
-    XSKDataStructureParser<?> parser = parserServices.get(type);
-    return parser.parse(location, content);
+    XSKDataStructureParser<?> parser = parserServices.get(parametersModel.getType());
+    return parser.parse(parametersModel);
   }
 
   @Override

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/synchronizer/XSKDataStructuresSynchronizer.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/synchronizer/XSKDataStructuresSynchronizer.java
@@ -18,6 +18,7 @@ import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.facade.IXSKHDBCoreFacade;
 import com.sap.xsk.hdb.ds.facade.XSKHDBCoreFacade;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureEntitiesModel;
 import com.sap.xsk.hdb.ds.model.hdbprocedure.XSKDataStructureHDBProcedureModel;
 import com.sap.xsk.hdb.ds.model.hdbschema.XSKDataStructureHDBSchemaModel;
@@ -34,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import com.sap.xsk.utils.XSKCommonsConstants;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.dirigible.core.scheduler.api.AbstractSynchronizer;
 import org.eclipse.dirigible.core.scheduler.api.SchedulerException;
@@ -85,8 +87,10 @@ public class XSKDataStructuresSynchronizer extends AbstractSynchronizer {
    */
   public void registerPredeliveredEntities(String contentPath) throws Exception {
     String data = loadResourceContent(contentPath);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(IXSKDataStructureModel.FILE_EXTENSION_ENTITIES, contentPath, data, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
     XSKDataStructureEntitiesModel model = (XSKDataStructureEntitiesModel) xskCoreParserService
-        .parseDataStructure(IXSKDataStructureModel.FILE_EXTENSION_ENTITIES, contentPath, data);
+        .parseDataStructure(parametersModel);
     ENTITIES_PREDELIVERED.put(contentPath, model);
   }
 
@@ -98,8 +102,10 @@ public class XSKDataStructuresSynchronizer extends AbstractSynchronizer {
    */
   public void registerPredeliveredTable(String contentPath) throws Exception {
     String data = loadResourceContent(contentPath);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(IXSKDataStructureModel.FILE_EXTENSION_TABLE, contentPath, data, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
     XSKDataStructureHDBTableModel model = (XSKDataStructureHDBTableModel) xskCoreParserService
-        .parseDataStructure(IXSKDataStructureModel.FILE_EXTENSION_TABLE, contentPath, data);
+        .parseDataStructure(parametersModel);
     TABLES_PREDELIVERED.put(contentPath, model);
   }
 
@@ -111,8 +117,10 @@ public class XSKDataStructuresSynchronizer extends AbstractSynchronizer {
    */
   public void registerPredeliveredView(String contentPath) throws Exception {
     String data = loadResourceContent(contentPath);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(IXSKDataStructureModel.FILE_EXTENSION_VIEW, contentPath, data, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
     XSKDataStructureHDBViewModel model = (XSKDataStructureHDBViewModel) xskCoreParserService
-        .parseDataStructure(IXSKDataStructureModel.FILE_EXTENSION_VIEW, contentPath, data);
+        .parseDataStructure(parametersModel);
     VIEWS_PREDELIVERED.put(contentPath, model);
   }
 
@@ -124,8 +132,10 @@ public class XSKDataStructuresSynchronizer extends AbstractSynchronizer {
    */
   public void registerPredeliveredSynonym(String contentPath) throws Exception {
     String data = loadResourceContent(contentPath);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(IXSKDataStructureModel.FILE_EXTENSION_SYNONYM, contentPath, data, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
     XSKDataStructureHDBSynonymModel model = (XSKDataStructureHDBSynonymModel) xskCoreParserService
-        .parseDataStructure(IXSKDataStructureModel.FILE_EXTENSION_SYNONYM, contentPath, data);
+        .parseDataStructure(parametersModel);
     SYNONYMS_PREDELIVERED.put(contentPath, model);
   }
 
@@ -139,9 +149,11 @@ public class XSKDataStructuresSynchronizer extends AbstractSynchronizer {
   public void registerPredeliveredHDBProcedure(String contentPath)
       throws IOException, XSKDataStructuresException, XSKArtifactParserException {
     String data = loadResourceContent(contentPath);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(IXSKDataStructureModel.FILE_EXTENSION_HDBPROCEDURE, contentPath, data, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
     XSKDataStructureHDBProcedureModel model;
     model = (XSKDataStructureHDBProcedureModel) xskCoreParserService
-        .parseDataStructure(IXSKDataStructureModel.FILE_EXTENSION_HDBPROCEDURE, contentPath, data);
+        .parseDataStructure(parametersModel);
     PROCEDURES_PREDELIVERED.put(contentPath, model);
   }
 
@@ -154,9 +166,11 @@ public class XSKDataStructuresSynchronizer extends AbstractSynchronizer {
   public void registerPredeliveredHDBTableFunction(String contentPath)
       throws IOException, XSKDataStructuresException, XSKArtifactParserException {
     String data = loadResourceContent(contentPath);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(IXSKDataStructureModel.FILE_EXTENSION_HDBTABLEFUNCTION, contentPath, data, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
     XSKDataStructureHDBTableFunctionModel model;
     model = (XSKDataStructureHDBTableFunctionModel) xskCoreParserService
-        .parseDataStructure(IXSKDataStructureModel.FILE_EXTENSION_HDBTABLEFUNCTION, contentPath, data);
+        .parseDataStructure(parametersModel);
     TABLEFUNCTIONS_PREDELIVERED.put(contentPath, model);
   }
 
@@ -170,9 +184,11 @@ public class XSKDataStructuresSynchronizer extends AbstractSynchronizer {
   public void registerPredeliveredHDBSchema(String contentPath)
       throws IOException, XSKDataStructuresException, XSKArtifactParserException {
     String data = loadResourceContent(contentPath);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(IXSKDataStructureModel.FILE_EXTENSION_HDBSCHEMA, contentPath, data, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
     XSKDataStructureHDBSchemaModel model;
     model = (XSKDataStructureHDBSchemaModel) xskCoreParserService
-        .parseDataStructure(IXSKDataStructureModel.FILE_EXTENSION_HDBSCHEMA, contentPath, data);
+        .parseDataStructure(parametersModel);
     SCHEMAS_PREDELIVERED.put(contentPath, model);
   }
 
@@ -184,8 +200,10 @@ public class XSKDataStructuresSynchronizer extends AbstractSynchronizer {
    */
   public void registerPredeliveredHDBStructure(String contentPath) throws Exception {
     String data = loadResourceContent(contentPath);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(IXSKDataStructureModel.FILE_EXTENSION_STRUCTURE, contentPath, data, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
     XSKDataStructureHDBTableTypeModel model = (XSKDataStructureHDBTableTypeModel) xskCoreParserService
-        .parseDataStructure(IXSKDataStructureModel.FILE_EXTENSION_STRUCTURE, contentPath, data);
+        .parseDataStructure(parametersModel);
     TABLE_TYPES_PREDELIVERED.put(contentPath, model);
   }
 

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/parser/XSKHDBSequenceParserTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/parser/XSKHDBSequenceParserTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertThrows;
 import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModelFactory;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbsequence.XSKDataStructureHDBSequenceModel;
 import com.sap.xsk.hdb.ds.parser.hdbsequence.XSKHDBSequenceParser;
 import com.sap.xsk.hdb.ds.test.module.HdbTestModule;
@@ -37,19 +38,22 @@ public class XSKHDBSequenceParserTest {
 
     @Test
     public void parseHanaXSClassicContent() throws Exception {
-        String content = org.apache.commons.io.IOUtils
-                .toString(XSKHDBSequenceParserTest.class.getResourceAsStream("/test/xsk/com/sap/SampleSequence_HanaXSClassic.hdbsequence"),
-                        StandardCharsets.UTF_8);
-        XSKDataStructureHDBSequenceModel model = (XSKDataStructureHDBSequenceModel) new XSKHDBSequenceParser()
-                .parse("/test/xsk/com/sap/SampleSequence_HanaXSClassic.hdbsequence", content);
+      String content = org.apache.commons.io.IOUtils
+              .toString(XSKHDBSequenceParserTest.class.getResourceAsStream("/test/xsk/com/sap/SampleSequence_HanaXSClassic.hdbsequence"),
+                      StandardCharsets.UTF_8);
 
-        assertEquals("MYSCHEMA", model.getSchema());
-        assertEquals(Integer.valueOf(10), model.getStartWith());
-        assertEquals(Integer.valueOf(30), model.getMaxValue());
-        assertEquals(false, model.getNoMaxValue());
-        assertEquals(true, model.getNoMinValue());
-        assertEquals(false, model.getCycles());
-        assertEquals(XSKDBContentType.XS_CLASSIC, model.getDBContentType());
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/test/xsk/com/sap/SampleSequence_HanaXSClassic.hdbsequence", content, null);
+      XSKDataStructureHDBSequenceModel model = (XSKDataStructureHDBSequenceModel) new XSKHDBSequenceParser()
+              .parse(parametersModel);
+
+      assertEquals("MYSCHEMA", model.getSchema());
+      assertEquals(Integer.valueOf(10), model.getStartWith());
+      assertEquals(Integer.valueOf(30), model.getMaxValue());
+      assertEquals(false, model.getNoMaxValue());
+      assertEquals(true, model.getNoMinValue());
+      assertEquals(false, model.getCycles());
+      assertEquals(XSKDBContentType.XS_CLASSIC, model.getDBContentType());
     }
 
     @Test
@@ -57,8 +61,10 @@ public class XSKHDBSequenceParserTest {
       String content = org.apache.commons.io.IOUtils
           .toString(XSKHDBSequenceParserTest.class.getResourceAsStream("/test/xsk/com/sap/SchemaOnlySequence.hdbsequence"),
               StandardCharsets.UTF_8);
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/test/xsk/com/sap/SchemaOnlySequence.hdbsequence", content, null);
       XSKDataStructureHDBSequenceModel model = (XSKDataStructureHDBSequenceModel) new XSKHDBSequenceParser()
-          .parse("/test/xsk/com/sap/SchemaOnlySequence.hdbsequence", content);
+          .parse(parametersModel);
       assertFalse(model.isPublic());
       assertEquals(Integer.valueOf(1), model.getStartWith());
       assertEquals(Integer.valueOf(1), model.getIncrementBy());
@@ -70,74 +76,87 @@ public class XSKHDBSequenceParserTest {
       String content = org.apache.commons.io.IOUtils
           .toString(XSKHDBSequenceParserTest.class.getResourceAsStream("/test/xsk/com/sap/DependsOnSequence.hdbsequence"),
               StandardCharsets.UTF_8);
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/test/xsk/com/sap/DependsOnSequence.hdbsequence", content, null);
       XSKDataStructureHDBSequenceModel model = (XSKDataStructureHDBSequenceModel) new XSKHDBSequenceParser()
-          .parse("/test/xsk/com/sap/DependsOnSequence.hdbsequence", content);
+          .parse(parametersModel);
       assertEquals("sap.ino.db.iam::t_identity", model.getDependsOnTable());
       assertEquals("sap.ino.db.iam::t_view", model.getDependsOnView());
     }
 
     @Test
     public void parseHanaXSAdvancedContent() throws Exception {
-        String content = org.apache.commons.io.IOUtils
-                .toString(XSKHDBSequenceParserTest.class.getResourceAsStream("/test/xsk/com/sap/CustomerId_HanaXSAdvanced.hdbsequence"),
-                        StandardCharsets.UTF_8);
-        XSKDataStructureHDBSequenceModel model = (XSKDataStructureHDBSequenceModel) new XSKHDBSequenceParser()
-                .parse("/test/xsk/com/sap/CustomerId_HanaXSAdvanced.hdbsequence", content);
-        assertEquals(XSKDBContentType.OTHERS, model.getDBContentType());
-        assertEquals(content, model.getRawContent());
+      String content = org.apache.commons.io.IOUtils
+              .toString(XSKHDBSequenceParserTest.class.getResourceAsStream("/test/xsk/com/sap/CustomerId_HanaXSAdvanced.hdbsequence"),
+                      StandardCharsets.UTF_8);
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/test/xsk/com/sap/CustomerId_HanaXSAdvanced.hdbsequence", content, null);
+      XSKDataStructureHDBSequenceModel model = (XSKDataStructureHDBSequenceModel) new XSKHDBSequenceParser()
+              .parse(parametersModel);
+      assertEquals(XSKDBContentType.OTHERS, model.getDBContentType());
+      assertEquals(content, model.getRawContent());
     }
 
 
     @Test
     public void parseGrammarUnreadableContent() throws Exception {
-        String content = "Some invalid content.";
-        assertThrows(XSKArtifactParserException.class, () -> new XSKHDBSequenceParser().parse("/test/xsk/com/sap/InvalidContent.hdbsequence", content));
+      String content = "Some invalid content.";
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/test/xsk/com/sap/InvalidContent.hdbsequence", content, null);
+      assertThrows(XSKArtifactParserException.class, () -> new XSKHDBSequenceParser().parse(parametersModel));
     }
 
 
     @Test
     public void parseRepetitiveProperties() throws Exception {
-        String content = org.apache.commons.io.IOUtils
-                .toString(XSKHDBSequenceParserTest.class.getResourceAsStream("/test/xsk/com/sap/RepetitivePropsSequence.hdbsequence"),
-                        StandardCharsets.UTF_8);
-
-        assertThrows(XSKHDBSequenceDuplicatePropertyException.class, () -> new XSKHDBSequenceParser().parse("/test/xsk/com/sap/RepetitivePropsSequence.hdbsequence", content));
+      String content = org.apache.commons.io.IOUtils
+              .toString(XSKHDBSequenceParserTest.class.getResourceAsStream("/test/xsk/com/sap/RepetitivePropsSequence.hdbsequence"),
+                      StandardCharsets.UTF_8);
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/test/xsk/com/sap/RepetitivePropsSequence.hdbsequence", content, null);
+      assertThrows(XSKHDBSequenceDuplicatePropertyException.class, () -> new XSKHDBSequenceParser().parse(parametersModel));
     }
 
     @Test
     public void parseRandomlyOrderedContent() throws Exception {
-        String content = org.apache.commons.io.IOUtils
-                .toString(XSKHDBSequenceParserTest.class.getResourceAsStream("/test/xsk/com/sap/RandomlyOrderedSequence.hdbsequence"),
-                        StandardCharsets.UTF_8);
-        XSKDataStructureHDBSequenceModel model = (XSKDataStructureHDBSequenceModel) new XSKHDBSequenceParser()
-                .parse("/test/xsk/com/sap/RandomlyOrderedSequence.hdbsequence", content);
+      String content = org.apache.commons.io.IOUtils
+              .toString(XSKHDBSequenceParserTest.class.getResourceAsStream("/test/xsk/com/sap/RandomlyOrderedSequence.hdbsequence"),
+                      StandardCharsets.UTF_8);
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/test/xsk/com/sap/RandomlyOrderedSequence.hdbsequence", content, null);
+      XSKDataStructureHDBSequenceModel model = (XSKDataStructureHDBSequenceModel) new XSKHDBSequenceParser()
+              .parse(parametersModel);
 
-        assertEquals("USR_9TCD6SXS67DP7AFLFE420B8EB", model.getSchema());
-        assertEquals(Integer.valueOf(10), model.getStartWith());
-        assertEquals(Integer.valueOf(30), model.getMaxValue());
-        assertEquals(false, model.getNoMaxValue());
-        assertEquals(true, model.getNoMinValue());
-        assertEquals(false, model.getCycles());
-        assertFalse(model.isPublic());
-        assertEquals(Integer.valueOf(-2), model.getIncrementBy());
-        assertEquals(XSKDBContentType.XS_CLASSIC, model.getDBContentType());
+      assertEquals("USR_9TCD6SXS67DP7AFLFE420B8EB", model.getSchema());
+      assertEquals(Integer.valueOf(10), model.getStartWith());
+      assertEquals(Integer.valueOf(30), model.getMaxValue());
+      assertEquals(false, model.getNoMaxValue());
+      assertEquals(true, model.getNoMinValue());
+      assertEquals(false, model.getCycles());
+      assertFalse(model.isPublic());
+      assertEquals(Integer.valueOf(-2), model.getIncrementBy());
+      assertEquals(XSKDBContentType.XS_CLASSIC, model.getDBContentType());
     }
 
 
     @Test
     public void parseMissingMandatoryProperty() throws Exception {
-        String content = org.apache.commons.io.IOUtils
-                .toString(XSKViewParserTest.class.getResourceAsStream("/test/xsk/com/sap/MissingPropSequence.hdbsequence"), StandardCharsets.UTF_8);
+      String content = org.apache.commons.io.IOUtils
+              .toString(XSKViewParserTest.class.getResourceAsStream("/test/xsk/com/sap/MissingPropSequence.hdbsequence"), StandardCharsets.UTF_8);
 
-        assertThrows(XSKHDBSequenceMissingPropertyException.class, () -> new XSKHDBSequenceParser().parse("/test/xsk/com/sap/MissingPropSequence.hdbsequence", content));
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/test/xsk/com/sap/MissingPropSequence.hdbsequence", content, null);
+      assertThrows(XSKHDBSequenceMissingPropertyException.class, () -> new XSKHDBSequenceParser().parse(parametersModel));
     }
 
     @Test
     public void parseNonQuotedSeq() throws Exception {
-        String content = "  SEQUENCE seq";
-        XSKDataStructureHDBSequenceModel model = (XSKDataStructureHDBSequenceModel) new XSKHDBSequenceParser()
-                .parse("/test/xsk/com/sap/someFileName.hdbsequence", content);
-        assertEquals(XSKDBContentType.OTHERS, model.getDBContentType());
+      String content = "  SEQUENCE seq";
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/test/xsk/com/sap/someFileName.hdbsequence", content, null);
+      XSKDataStructureHDBSequenceModel model = (XSKDataStructureHDBSequenceModel) new XSKHDBSequenceParser()
+              .parse(parametersModel);
+      assertEquals(XSKDBContentType.OTHERS, model.getDBContentType());
     }
 
     @Test(expected = XSKArtifactParserException.class)

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/parser/XSKSynonymParserTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/parser/XSKSynonymParserTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import org.eclipse.dirigible.api.v3.problems.ProblemsFacade;
 import org.eclipse.dirigible.core.test.AbstractDirigibleTest;
 import org.junit.Before;
@@ -61,7 +62,9 @@ public class XSKSynonymParserTest extends AbstractDirigibleTest {
         + "}";
     String errorMessage = "Missing mandatory field for synonym SY_DUMMY!";
     XSKSynonymParser parser = new XSKSynonymParser();
-    parser.parse("hdb_view/MySynonym.hdbsynonym", content);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, "hdb_view/MySynonym.hdbsynonym", content, null);
+    parser.parse(parametersModel);
     assertTrue(ProblemsFacade.fetchAllProblems().contains(errorMessage));
   }
 }

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/parser/XSKTableParserTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/parser/XSKTableParserTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.dirigible.core.test.AbstractDirigibleTest;
 import org.junit.Test;
@@ -105,45 +106,51 @@ public class XSKTableParserTest extends AbstractDirigibleTest {
 
     @Test
     public void failIfParsingRepetitiveProperties() throws Exception {
-        InputStream in = XSKTableParserTest.class.getResourceAsStream("/DuplicateTableProperties.hdbtable");
-        String content = IOUtils.toString(in, StandardCharsets.UTF_8);
-
-        assertThrows(XSKHDBTableDuplicatePropertyException.class, () -> new XSKTableParser().parse("/DuplicateTableProperties.hdbtable", content));
+      InputStream in = XSKTableParserTest.class.getResourceAsStream("/DuplicateTableProperties.hdbtable");
+      String content = IOUtils.toString(in, StandardCharsets.UTF_8);
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/DuplicateTableProperties.hdbtable", content, null);
+      assertThrows(XSKHDBTableDuplicatePropertyException.class, () -> new XSKTableParser().parse(parametersModel));
     }
 
     @Test(expected = XSKHDBTableMissingPropertyException.class)
     public void failIfParsingMissingMandatoryProperties() throws Exception {
-        InputStream in = XSKTableParserTest.class.getResourceAsStream("/MissingMandatoryTableProperties.hdbtable");
-        String content = IOUtils.toString(in, StandardCharsets.UTF_8);
-
-        new XSKTableParser().parse("/MissingMandatoryTableProperties.hdbtable", content);
+      InputStream in = XSKTableParserTest.class.getResourceAsStream("/MissingMandatoryTableProperties.hdbtable");
+      String content = IOUtils.toString(in, StandardCharsets.UTF_8);
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/MissingMandatoryTableProperties.hdbtable", content, null);
+      new XSKTableParser().parse(parametersModel);
     }
 
     @Test
     public void failIfParsingWrongPKDefinition() {
-        String content = "table.schemaName = \"SPORTS\";\n" +
-                "table.tableType = COLUMNSTORE;\n" +
-                "table.columns = [\n" +
-                "\t{ name = \"MATCH_ID\";\tsqlType = NVARCHAR;},\n" +
-                "\t{ name = \"TEAM_ID\";\t\tsqlType = NVARCHAR;}\n" +
-                "];\n" +
-                "table.primaryKey.pkcolumns = [\"MATCH_ID_WRONG\", \"TEAM_ID\"];";
+      String content = "table.schemaName = \"SPORTS\";\n" +
+              "table.tableType = COLUMNSTORE;\n" +
+              "table.columns = [\n" +
+              "\t{ name = \"MATCH_ID\";\tsqlType = NVARCHAR;},\n" +
+              "\t{ name = \"TEAM_ID\";\t\tsqlType = NVARCHAR;}\n" +
+              "];\n" +
+              "table.primaryKey.pkcolumns = [\"MATCH_ID_WRONG\", \"TEAM_ID\"];";
 
-        assertThrows(IllegalStateException.class, () -> new XSKTableParser().parse("/someFileName.hdbtable", content));
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/someFileName.hdbtable", content, null);
+      assertThrows(IllegalStateException.class, () -> new XSKTableParser().parse(parametersModel));
     }
 
     @Test
     public void failIfParsingWrongIndexDefinition() {
-        String content = "table.schemaName = \"SPORTS\";\n" +
-                "table.tableType = COLUMNSTORE;\n" +
-                "table.columns = [\n" +
-                "\t{ name = \"MATCH_ID\";\tsqlType = NVARCHAR;},\n" +
-                "\t{ name = \"TEAM_ID\";\t\tsqlType = NVARCHAR;}\n" +
-                "];\n" +
-                "table.primaryKey.pkcolumns = [\"MATCH_ID\", \"TEAM_ID\"];" +
-                "table.indexes = [ {name = \"INDEX1\"; unique = true; indexColumns = [\"MATCH_ID_WRONG\"];}];";
+      String content = "table.schemaName = \"SPORTS\";\n" +
+              "table.tableType = COLUMNSTORE;\n" +
+              "table.columns = [\n" +
+              "\t{ name = \"MATCH_ID\";\tsqlType = NVARCHAR;},\n" +
+              "\t{ name = \"TEAM_ID\";\t\tsqlType = NVARCHAR;}\n" +
+              "];\n" +
+              "table.primaryKey.pkcolumns = [\"MATCH_ID\", \"TEAM_ID\"];" +
+              "table.indexes = [ {name = \"INDEX1\"; unique = true; indexColumns = [\"MATCH_ID_WRONG\"];}];";
 
-        assertThrows(IllegalStateException.class, () -> new XSKTableParser().parse("/someFileName.hdbtable", content));
+      XSKDataStructureParametersModel parametersModel =
+          new XSKDataStructureParametersModel(null, "/someFileName.hdbtable", content, null);
+      assertThrows(IllegalStateException.class, () -> new XSKTableParser().parse(parametersModel));
     }
 
     @Test

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/parser/XSKTableTypeParserTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/parser/XSKTableTypeParserTest.java
@@ -20,6 +20,7 @@ import com.sap.xsk.exceptions.XSKArtifactParserException;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
 import com.sap.xsk.hdb.ds.model.XSKDBContentType;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModelFactory;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableColumnModel;
 import com.sap.xsk.hdb.ds.model.hdbtabletype.XSKDataStructureHDBTableTypeModel;
 import com.sap.xsk.hdb.ds.parser.hdbtabletype.XSKTableTypeParser;
@@ -68,7 +69,9 @@ public class XSKTableTypeParserTest extends AbstractDirigibleTest {
         "\t{ name = \"PERIOD_ID\";\t\tsqlType = DECIMAL;}\n" +
         "];\n" +
         "table.primaryKey.pkcolumns = [\"SCENARIO_ID_WRONG\", \"PERIOD_ID\"];";
-    parser.parse("/temp.hdbstructure", content);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, "/temp.hdbstructure", content, null);
+    parser.parse(parametersModel);
   }
 
   @Test

--- a/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/hdi/synchronizer/XSKDataStructuresHDISynchronizer.java
+++ b/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/hdi/synchronizer/XSKDataStructuresHDISynchronizer.java
@@ -17,6 +17,7 @@ import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.IXSKDataStructuresCoreService;
 import com.sap.xsk.hdb.ds.api.IXSKEnvironmentVariables;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdi.XSKDataStructureHDIModel;
 import com.sap.xsk.hdb.ds.processors.hdi.XSKHDIContainerCreateProcessor;
 import com.sap.xsk.hdb.ds.processors.hdi.XSKHDIContainerDropProcessor;
@@ -37,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
+import com.sap.xsk.utils.XSKCommonsConstants;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.commons.config.StaticObjects;
@@ -150,8 +152,10 @@ public class XSKDataStructuresHDISynchronizer extends AbstractSynchronizer {
    */
   public void registerPredeliveredHDI(String contentPath) throws Exception {
     String data = loadResourceContent(contentPath);
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(IXSKDataStructureModel.TYPE_HDI, contentPath, data, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
     XSKDataStructureHDIModel model = (XSKDataStructureHDIModel) xskCoreParserService
-        .parseDataStructure(IXSKDataStructureModel.TYPE_HDI, contentPath, data);
+        .parseDataStructure(parametersModel);
     HDI_PREDELIVERED.put(contentPath, model);
   }
 
@@ -259,8 +263,10 @@ public class XSKDataStructuresHDISynchronizer extends AbstractSynchronizer {
         String contentAsString = getContent(resource);
         XSKDataStructureHDIModel hdi;
         try {
+          XSKDataStructureParametersModel parametersModel =
+              new XSKDataStructureParametersModel(IXSKDataStructureModel.TYPE_HDI, registryPath, contentAsString, XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
           hdi = (XSKDataStructureHDIModel) xskCoreParserService
-              .parseDataStructure(IXSKDataStructureModel.TYPE_HDI, registryPath, contentAsString);
+              .parseDataStructure(parametersModel);
         } catch (XSKDataStructuresException e) {
           logger.error("Synchronized hdi artifact is not valid");
           logger.error(e.getMessage());

--- a/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/parser/hdi/XSKHDIParser.java
+++ b/modules/engines/engine-hdi/src/main/java/com/sap/xsk/hdb/ds/parser/hdi/XSKHDIParser.java
@@ -15,6 +15,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdi.XSKDataStructureHDIModel;
 import com.sap.xsk.hdb.ds.parser.XSKDataStructureParser;
 import java.io.File;
@@ -27,19 +28,19 @@ import org.eclipse.dirigible.api.v3.security.UserFacade;
 public class XSKHDIParser implements XSKDataStructureParser {
 
   @Override
-  public XSKDataStructureHDIModel parse(String location, String content) throws XSKDataStructuresException, IOException {
+  public XSKDataStructureHDIModel parse(XSKDataStructureParametersModel parametersModel) throws XSKDataStructuresException, IOException {
     Gson gson = new GsonBuilder()
         .registerTypeAdapter(XSKDataStructureHDIModel.class, new XSKHDIModelAdapter())
         .create();
 
-    XSKDataStructureHDIModel hdiModel = gson.fromJson(content, XSKDataStructureHDIModel.class);
-    hdiModel.setName(new File(location).getName());
-    hdiModel.setLocation(location);
+    XSKDataStructureHDIModel hdiModel = gson.fromJson(parametersModel.getContent(), XSKDataStructureHDIModel.class);
+    hdiModel.setName(new File(parametersModel.getLocation()).getName());
+    hdiModel.setLocation(parametersModel.getLocation());
     hdiModel.setType(getType());
-    hdiModel.setHash(DigestUtils.md5Hex(content));
+    hdiModel.setHash(DigestUtils.md5Hex(parametersModel.getContent()));
     hdiModel.setCreatedBy(UserFacade.getName());
     hdiModel.setCreatedAt(new Timestamp(new java.util.Date().getTime()));
-    hdiModel.setContent(content);
+    hdiModel.setContent(parametersModel.getContent());
     return hdiModel;
   }
 

--- a/modules/engines/engine-hdi/src/test/java/com/sap/xsk/hdi/parser/XSKHDIParserTest.java
+++ b/modules/engines/engine-hdi/src/test/java/com/sap/xsk/hdi/parser/XSKHDIParserTest.java
@@ -14,6 +14,7 @@ package com.sap.xsk.hdi.parser;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 import com.sap.xsk.hdb.ds.api.XSKDataStructuresException;
+import com.sap.xsk.hdb.ds.model.XSKDataStructureParametersModel;
 import com.sap.xsk.hdb.ds.model.hdi.XSKDataStructureHDIModel;
 import com.sap.xsk.hdb.ds.parser.hdi.XSKHDIParser;
 import org.junit.Test;
@@ -29,7 +30,10 @@ public class XSKHDIParserTest {
     String location = "/ValidHDIContent.hdi";
     String content = org.apache.commons.io.IOUtils
         .toString(XSKHDIParserTest.class.getResourceAsStream(location), StandardCharsets.UTF_8);
-    XSKDataStructureHDIModel model = new XSKHDIParser().parse(location, content);
+
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, null);
+    XSKDataStructureHDIModel model = new XSKHDIParser().parse(parametersModel);
     assertEquals("/hdi-ext/config.hdiconfig", model.getConfiguration());
     assertEquals(new String[]{"DBADMIN"}, model.getUsers());
     assertEquals("/hdi-ext/config.hdiconfig", model.getConfiguration());
@@ -45,7 +49,9 @@ public class XSKHDIParserTest {
     String location = "/NonStringProperties.hdi";
     String content = org.apache.commons.io.IOUtils
         .toString(XSKHDIParserTest.class.getResourceAsStream(location), StandardCharsets.UTF_8);
-    assertThrows(JsonSyntaxException.class, () -> new XSKHDIParser().parse(location, content));
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, null);
+    assertThrows(JsonSyntaxException.class, () -> new XSKHDIParser().parse(parametersModel));
   }
 
   @Test
@@ -53,7 +59,9 @@ public class XSKHDIParserTest {
     String location = "/MissingMandatoryProperty.hdi";
     String content = org.apache.commons.io.IOUtils
         .toString(XSKHDIParserTest.class.getResourceAsStream(location), StandardCharsets.UTF_8);
-    assertThrows(JsonParseException.class, () -> new XSKHDIParser().parse(location, content));
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, null);
+    assertThrows(JsonParseException.class, () -> new XSKHDIParser().parse(parametersModel));
   }
 
   @Test
@@ -61,7 +69,9 @@ public class XSKHDIParserTest {
     String location = "/SameDeploymentFile.hdi";
     String content = org.apache.commons.io.IOUtils
         .toString(XSKHDIParserTest.class.getResourceAsStream(location), StandardCharsets.UTF_8);
-    assertThrows(JsonParseException.class, () -> new XSKHDIParser().parse(location, content));
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, null);
+    assertThrows(JsonParseException.class, () -> new XSKHDIParser().parse(parametersModel));
   }
 
   @Test
@@ -69,6 +79,8 @@ public class XSKHDIParserTest {
     String location = "/NoDeploymentFiles.hdi";
     String content = org.apache.commons.io.IOUtils
         .toString(XSKHDIParserTest.class.getResourceAsStream(location), StandardCharsets.UTF_8);
-    assertThrows(JsonParseException.class, () -> new XSKHDIParser().parse(location, content));
+    XSKDataStructureParametersModel parametersModel =
+        new XSKDataStructureParametersModel(null, location, content, null);
+    assertThrows(JsonParseException.class, () -> new XSKHDIParser().parse(parametersModel));
   }
 }

--- a/modules/ide/ide-migration/pom.xml
+++ b/modules/ide/ide-migration/pom.xml
@@ -95,6 +95,12 @@
       <version>${dirigible.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.sap.xsk</groupId>
+      <artifactId>xsk-modules-engines-hdb</artifactId>
+      <version>0.13.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/modules/ide/ide-migration/src/main/resources/META-INF/dirigible/ide-migration/server/migration/api/migration-service.js
+++ b/modules/ide/ide-migration/src/main/resources/META-INF/dirigible/ide-migration/server/migration/api/migration-service.js
@@ -176,7 +176,7 @@ class MigrationService {
             const fileContent = String.fromCharCode.apply(String, content).replace(/\0/g,'');
 
             // Parse current artifacts and generate synonym files for it if necessary
-            const parsedData = facade.parseDataStructureModel(fileName, filePath, fileContent);
+            const parsedData = facade.parseDataStructureModel(fileName, filePath, fileContent, "/workspace/");
             const generatedSynonymFiles = this.handleParsedData(parsedData, workspaceName, projectName, fileRunLocation);
 
             for(const generatedSynonymFile of generatedSynonymFiles) {

--- a/modules/ide/ide-migration/src/main/resources/META-INF/dirigible/ide-migration/server/migration/process/handle-deployables-task.js
+++ b/modules/ide/ide-migration/src/main/resources/META-INF/dirigible/ide-migration/server/migration/process/handle-deployables-task.js
@@ -22,18 +22,31 @@ try {
 	const userData = JSON.parse(userDataJson);
 
 	const migrationService = new MigrationService();
-
+    var projectNames = [];
     for (const deliveryUnit of userData.du) {
         const locals = deliveryUnit.locals;
         let deployables = [];
         for (const local of locals) {
             deployables = migrationService.collectDeployables(
-				userData.workspace, 
-				local.repositoryPath, 
-				local.runLocation, 
-				local.projectName, 
-				deployables
-			);
+                userData.workspace,
+                local.repositoryPath,
+                local.runLocation,
+                local.projectName,
+                deployables
+            );
+
+            if(local.runLocation === "/" + local.projectName + "/" + migrationService.synonymFileName
+            || local.runLocation === "/" + local.projectName + "/" + migrationService.publicSynonymFileName) {
+                if(!projectNames.includes(local.projectName)) {
+                    projectNames.push(local.projectName);
+                }
+            }
+        }
+
+        // Add synonym files to deployables
+        for(const projectName of projectNames) {
+            deployables.find(x => x.projectName === projectName).artifacts.push("/" + projectName + "/" + migrationService.synonymFileName);
+            deployables.find(x => x.projectName === projectName).artifacts.push("/" + projectName + "/" + migrationService.publicSynonymFileName);
         }
         deliveryUnit['deployableArtifactsResult'] = migrationService.handlePossibleDeployableArtifacts(userData.workspace, deployables);
     }


### PR DESCRIPTION
- The parsers are now called once during migration to parse the artifacts inside the temporary directory.
- Hdb synonyms and hdb publicsynonyms are generated for `all` the artifacts can be parsed.
Note: These synonyms are inside two new files (`.hdbsynonym`, `.hdbpublicsynonym`) added to the workspace for each project in the migrated delivery unit.
- The hdiconfig is updated with the required synonym plugins.
- The hdi file for each project contains the synonym files.
- The parser intefraces and tests are refactored, so that the hdbdd parser can work with the temporary directory.

Fixes #1030, fixes #872 