### PR TITLE
fix: integration tests failing due to login changes in xsk

### DIFF
--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/DirigibleConnectionProperties.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/DirigibleConnectionProperties.java
@@ -1,9 +1,12 @@
 package com.xsk.integration.tests.migration;
 
 class DirigibleConnectionProperties {
+
   static final String HOST = "127.0.0.1";
   static final String PORT = "8080";
   static final String IDE_URI = "/services/v4/web/ide/";
-  static final String AUTH = "dirigible:dirigible";
+  static final String AUTH_USERNAME = "dirigible";
+  static final String AUTH_PASSWORD = "dirigible";
+  static final String AUTH = AUTH_USERNAME + ":" + AUTH_PASSWORD;
   static final String BASE_URL = "http://" + AUTH + "@" + HOST + ":" + PORT + IDE_URI;
 }

--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
@@ -62,7 +62,7 @@ public class MigrationITest {
   }
 
   private void setup(String param) {
-    webBrowser = new WebBrowser(param, DirigibleConnectionProperties.BASE_URL, false);
+    webBrowser = new WebBrowser(param, DirigibleConnectionProperties.BASE_URL, true);
     credentials = new MigrationCredentials(param.contains("Hana2"));
     expectedContentList = expectedContentProvider.getExpectedContentList();
   }

--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
@@ -74,8 +74,8 @@ public class MigrationITest {
       return; // assume we're already logged in
     }
 
-    webBrowser.enterAndAssertField(By.xpath("//input[@placeholder='Username']"), "dirigible");
-    webBrowser.enterAndAssertField(By.xpath("//input[@placeholder='Password']"), "dirigible");
+    webBrowser.enterAndAssertField(By.xpath("//input[@placeholder='Username']"), DirigibleConnectionProperties.AUTH_USERNAME);
+    webBrowser.enterAndAssertField(By.xpath("//input[@placeholder='Password']"), DirigibleConnectionProperties.AUTH_PASSWORD);
     webBrowser.clickItem(By.xpath("//button[text() = 'Log in']"));
   }
 

--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
@@ -51,6 +51,7 @@ public class MigrationITest {
   @Parameters({"Migration-Chrome-Hana1", /*"Migration-Chrome-Hana2",*/ "Migration-Firefox-Hana1", /*"Migration-Firefox-Hana2"*/})
   public void migrationTest(String param) throws IOException {
     setup(param);
+    loginIfNecessary();
     navigateToMigrationPerspective();
     enterNeoDBTunnelCredentials();
     enterHanaCredentials();
@@ -61,9 +62,21 @@ public class MigrationITest {
   }
 
   private void setup(String param) {
-    webBrowser = new WebBrowser(param, DirigibleConnectionProperties.BASE_URL, true);
+    webBrowser = new WebBrowser(param, DirigibleConnectionProperties.BASE_URL, false);
     credentials = new MigrationCredentials(param.contains("Hana2"));
     expectedContentList = expectedContentProvider.getExpectedContentList();
+  }
+
+  private void loginIfNecessary() {
+    try {
+      webBrowser.waitForVisibilityOfElement(By.xpath("/html/body/div/div/h3[text() = 'Sign in to Eclipse Dirigible']"));
+    } catch (Throwable t) {
+      return; // assume we're already logged in
+    }
+
+    webBrowser.enterAndAssertField(By.xpath("//input[@placeholder='Username']"), "dirigible");
+    webBrowser.enterAndAssertField(By.xpath("//input[@placeholder='Password']"), "dirigible");
+    webBrowser.clickItem(By.xpath("//button[text() = 'Log in']"));
   }
 
   private void navigateToMigrationPerspective() {


### PR DESCRIPTION
Due to a change in the XSK/Dirigible, we cannot log in using the Basic auth url scheme: 
`http://<user>:<password>@localhost:8080/services/v4/web/ide/`

This PR fixes the Migration integration test to login manually if necessary.