### PR TITLE
feat: remove the java 8 dependency for the neo sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,8 @@
 		<selenium.version>4.1.1</selenium.version>
 		<selenium.webdriver.manager.version>5.0.3</selenium.webdriver.manager.version>
 		<neo-java-web-sdk.version>4.8.9</neo-java-web-sdk.version>
+    <neo-java-web-sdk.javax.activation.version>1.2.0</neo-java-web-sdk.javax.activation.version>
+    <neo-java-web-sdk.jaxb.version>2.2.11</neo-java-web-sdk.jaxb.version>
 		<ngdbc.version>2.11.14</ngdbc.version>
 		<maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
 		<commons-csv.version>1.9.0</commons-csv.version>

--- a/releng/developer/Dockerfile
+++ b/releng/developer/Dockerfile
@@ -28,27 +28,6 @@ FROM base AS xsk-default-jdk
 RUN echo "The default OpenJDK will be used"
 
 FROM xsk-${JDK_TYPE} AS dependencies-base
-####################
-### Java 8 Setup ###
-####################
-# Install OpenJDK-8
-RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
-    apt-get clean;
-
-# Fix certificate issues
-RUN apt-get update && \
-    apt-get install ca-certificates-java && \
-    apt-get clean && \
-    update-ca-certificates -f;
-
-# Setup JAVA8_HOME for Neo SDK
-ENV JAVA8_HOME /usr/lib/jvm/java-8-openjdk-amd64/
-RUN export JAVA8_HOME
-####################
-### Java 8 Setup ###
-####################
 
 RUN rm -R /usr/local/tomcat/webapps/*
 COPY target/ROOT.war $CATALINA_HOME/webapps/

--- a/releng/sap-cf/Dockerfile
+++ b/releng/sap-cf/Dockerfile
@@ -18,27 +18,6 @@ FROM base AS xsk-default-jdk
 RUN echo "The default OpenJDK will be used"
 
 FROM xsk-${JDK_TYPE} AS dependencies-base
-####################
-### Java 8 Setup ###
-####################
-# Install OpenJDK-8
-RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
-    apt-get clean;
-
-# Fix certificate issues
-RUN apt-get update && \
-    apt-get install ca-certificates-java && \
-    apt-get clean && \
-    update-ca-certificates -f;
-
-# Setup JAVA8_HOME for Neo SDK
-ENV JAVA8_HOME /usr/lib/jvm/java-8-openjdk-amd64/
-RUN export JAVA8_HOME
-####################
-### Java 8 Setup ###
-####################
 
 RUN rm -R /usr/local/tomcat/webapps/*
 COPY target/ROOT.war $CATALINA_HOME/webapps/

--- a/releng/sap-kyma/Dockerfile
+++ b/releng/sap-kyma/Dockerfile
@@ -18,27 +18,6 @@ FROM base AS xsk-default-jdk
 RUN echo "The default OpenJDK will be used"
 
 FROM xsk-${JDK_TYPE} AS dependencies-base
-####################
-### Java 8 Setup ###
-####################
-# Install OpenJDK-8
-RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
-    apt-get clean;
-
-# Fix certificate issues
-RUN apt-get update && \
-    apt-get install ca-certificates-java && \
-    apt-get clean && \
-    update-ca-certificates -f;
-
-# Setup JAVA8_HOME for Neo SDK
-ENV JAVA8_HOME /usr/lib/jvm/java-8-openjdk-amd64/
-RUN export JAVA8_HOME
-####################
-### Java 8 Setup ###
-####################
 
 RUN rm -R /usr/local/tomcat/webapps/*
 COPY target/ROOT.war $CATALINA_HOME/webapps/

--- a/releng/server/Dockerfile
+++ b/releng/server/Dockerfile
@@ -18,27 +18,6 @@ FROM base AS xsk-default-jdk
 RUN echo "The default OpenJDK will be used"
 
 FROM xsk-${JDK_TYPE} AS dependencies-base
-####################
-### Java 8 Setup ###
-####################
-# Install OpenJDK-8
-RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y ant && \
-    apt-get clean;
-
-# Fix certificate issues
-RUN apt-get update && \
-    apt-get install ca-certificates-java && \
-    apt-get clean && \
-    update-ca-certificates -f;
-
-# Setup JAVA8_HOME for Neo SDK
-ENV JAVA8_HOME /usr/lib/jvm/java-8-openjdk-amd64/
-RUN export JAVA8_HOME
-####################
-### Java 8 Setup ###
-####################
 
 RUN rm -R /usr/local/tomcat/webapps/*
 COPY target/ROOT.war $CATALINA_HOME/webapps/

--- a/resources/resources-neo-sdk/pom.xml
+++ b/resources/resources-neo-sdk/pom.xml
@@ -40,6 +40,49 @@
 							</artifactItems>
 						</configuration>
 					</execution>
+          <execution>
+            <id>copy</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>javax.activation</artifactId>
+                  <version>${neo-java-web-sdk.javax.activation.version}</version>
+                  <type>jar</type>
+                  <outputDirectory>src/main/resources/META-INF/dirigible/resources-neo-sdk/tools/lib/cmd</outputDirectory>
+                  <overWrite>true</overWrite>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>javax.xml.bind</groupId>
+                  <artifactId>jaxb-api</artifactId>
+                  <version>${neo-java-web-sdk.jaxb.version}</version>
+                  <type>jar</type>
+                  <outputDirectory>src/main/resources/META-INF/dirigible/resources-neo-sdk/tools/lib/cmd</outputDirectory>
+                  <overWrite>true</overWrite>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.sun.xml.bind</groupId>
+                  <artifactId>jaxb-core</artifactId>
+                  <version>${neo-java-web-sdk.jaxb.version}</version>
+                  <type>jar</type>
+                  <outputDirectory>src/main/resources/META-INF/dirigible/resources-neo-sdk/tools/lib/cmd</outputDirectory>
+                  <overWrite>true</overWrite>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.sun.xml.bind</groupId>
+                  <artifactId>jaxb-impl</artifactId>
+                  <version>${neo-java-web-sdk.jaxb.version}</version>
+                  <type>jar</type>
+                  <outputDirectory>src/main/resources/META-INF/dirigible/resources-neo-sdk/tools/lib/cmd</outputDirectory>
+                  <overWrite>true</overWrite>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
 				</executions>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Related to: https://github.com/SAP/xsk/issues/1120
Depends on: https://github.com/eclipse/dirigible/pull/1487

Do not ship Java 8 runtimes and provide necessary JARs to the Neo SDK to work with Java 11+. The JAXB JARs are downloaded into the `libs` folder into the Neo SDK as the `neo.sh` overrides the classpath and we can't just run it with our own `$CLASSPATH` env var. 

For this to be merged, the changes in the Dirigible should be merged or at least reconfigure somehow the ExecFacade to not redirect the error stream to the out stream as when running the Neo SDK with Java 11 has some warnings written in the error stream and this breaks the parsing of the results. These warnings are not expected to break something and are related to the Java module system from Java 9+. We can fix them at some point in time but this is not a high priority for now.