### PR TITLE
fix: remove powermock dependencies in db itests

### DIFF
--- a/integration-tests/engine-hdb/pom.xml
+++ b/integration-tests/engine-hdb/pom.xml
@@ -53,18 +53,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock-module-junit4.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock-api-mockito2.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>


### PR DESCRIPTION
Due to some PowerMock dependencies, the tests are not being able to compile. This PR removes the PowerMock dependencies.