### PR TITLE
Fix XSKTableCreateProcessor and minor refactoring

### DIFF
--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/facade/XSKTopologyDataStructureModelWrapper.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/facade/XSKTopologyDataStructureModelWrapper.java
@@ -21,9 +21,7 @@ import com.sap.xsk.hdb.ds.artefacts.HDBTableTypeSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.artefacts.HDBViewSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureDependencyModel;
 import com.sap.xsk.hdb.ds.model.XSKDataStructureModel;
-import com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureCdsModel;
 import com.sap.xsk.hdb.ds.model.hdbprocedure.XSKDataStructureHDBProcedureModel;
-import com.sap.xsk.hdb.ds.model.hdbscalarfunction.XSKDataStructureHDBScalarFunctionModel;
 import com.sap.xsk.hdb.ds.model.hdbschema.XSKDataStructureHDBSchemaModel;
 import com.sap.xsk.hdb.ds.model.hdbsequence.XSKDataStructureHDBSequenceModel;
 import com.sap.xsk.hdb.ds.model.hdbsynonym.XSKDataStructureHDBSynonymModel;
@@ -193,7 +191,7 @@ public class XSKTopologyDataStructureModelWrapper implements ITopologicallySorta
           break;
         case EXECUTE_TABLE_CREATE:
           if (model instanceof XSKDataStructureHDBTableModel) {
-            String escapedName = XSKHDBUtils.escapeArtifactName(connection, model.getName(), model.getSchema());
+            String escapedName = XSKHDBUtils.escapeArtifactName(model.getName(), model.getSchema());
             if (!SqlFactory.getNative(connection).exists(connection, escapedName)) {
               xskTableManagerService.createDataStructure(connection, this.model);
             } else {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityAlterProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityAlterProcessor.java
@@ -71,7 +71,7 @@ public class XSKEntityAlterProcessor {
 
     // ADD iteration
     for (XSKDataStructureHDBTableColumnModel columnModel : entityModel.getColumns()) {
-      String name = XSKHDBUtils.escapeArtifactName(connection, columnModel.getName());
+      String name = XSKHDBUtils.escapeArtifactName(columnModel.getName());
       DataType type = DataType.valueOf(columnModel.getType());
       String length = columnModel.getLength();
       boolean isNullable = columnModel.isNullable();
@@ -114,12 +114,14 @@ public class XSKEntityAlterProcessor {
 
         if (!isNullable) {
           String errorMessage = String.format(INCOMPATIBLE_CHANGE_OF_ENTITY, entityName, name, "NOT NULL");
-          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.HDB_ENTITY_PROCESSOR);
+          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+              XSKCommonsConstants.HDB_ENTITY_PROCESSOR);
           throw new SQLException(errorMessage);
         }
         if (isPrimaryKey) {
           String errorMessage = String.format(INCOMPATIBLE_CHANGE_OF_ENTITY, entityName, name, "PRIMARY KEY");
-          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.HDB_ENTITY_PROCESSOR);
+          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+              XSKCommonsConstants.HDB_ENTITY_PROCESSOR);
           throw new SQLException(errorMessage);
         }
 
@@ -128,7 +130,8 @@ public class XSKEntityAlterProcessor {
       } else if (!columnDefinitions.get(name.toUpperCase()).equals(type.toString())) {
         String errorMessage = String.format(INCOMPATIBLE_CHANGE_OF_ENTITY, entityName, name,
             "of type " + columnDefinitions.get(name) + " to be changed to " + type);
-        XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.HDB_ENTITY_PROCESSOR);
+        XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+            XSKCommonsConstants.HDB_ENTITY_PROCESSOR);
         throw new SQLException(errorMessage);
       }
     }
@@ -152,7 +155,8 @@ public class XSKEntityAlterProcessor {
     } catch (SQLException e) {
       logger.error(sql);
       logger.error(e.getMessage(), e);
-      XSKCommonsUtils.logProcessorErrors(e.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.HDB_ENTITY_PROCESSOR);
+      XSKCommonsUtils.logProcessorErrors(e.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+          XSKCommonsConstants.HDB_ENTITY_PROCESSOR);
       throw new SQLException(e.getMessage(), e);
     }
   }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityCreateProcessor.java
@@ -11,19 +11,6 @@
  */
 package com.sap.xsk.hdb.ds.processors.entity;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
-import org.eclipse.dirigible.database.sql.DataType;
-import org.eclipse.dirigible.database.sql.ISqlKeywords;
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.eclipse.dirigible.database.sql.builders.table.CreateTableBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sap.xsk.hdb.ds.artefacts.HDBDDEntitySynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureEntityModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableColumnModel;
@@ -32,6 +19,17 @@ import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
 import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.utils.XSKHDBUtils;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
+import org.eclipse.dirigible.database.sql.DataType;
+import org.eclipse.dirigible.database.sql.ISqlKeywords;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.builders.table.CreateTableBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Entity Create Processor.
@@ -49,13 +47,13 @@ public class XSKEntityCreateProcessor extends AbstractXSKProcessor<XSKDataStruct
    * @throws SQLException the SQL exception
    */
   public void execute(Connection connection, XSKDataStructureEntityModel entityModel) throws SQLException {
-    String tableName = XSKHDBUtils.escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel));
+    String tableName = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel));
     logger.info("Processing Create Table: {}", tableName);
     CreateTableBuilder createTableBuilder = SqlFactory.getNative(connection).create().table(tableName);
     List<XSKDataStructureHDBTableColumnModel> columns = entityModel.getColumns();
     List<String> primaryKeyColumns = new ArrayList<>();
     for (XSKDataStructureHDBTableColumnModel columnModel : columns) {
-      String name = XSKHDBUtils.escapeArtifactName(connection, columnModel.getName());
+      String name = XSKHDBUtils.escapeArtifactName(columnModel.getName());
       DataType type = DataType.valueOf(columnModel.getType());
       String length = columnModel.getLength();
       boolean isNullable = columnModel.isNullable();
@@ -104,14 +102,14 @@ public class XSKEntityCreateProcessor extends AbstractXSKProcessor<XSKDataStruct
           String foreignKeyName = "FK_" + foreignKey.getName();
           String[] fkColumns = foreignKey.getColumns();
           String referencedTable = XSKHDBUtils
-              .escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel, foreignKey.getReferencedTable()));
+              .escapeArtifactName(XSKHDBUtils.getTableName(entityModel, foreignKey.getReferencedTable()));
           String[] referencedColumns = foreignKey.getReferencedColumns();
-          foreignKeyName = XSKHDBUtils.escapeArtifactName(connection, foreignKeyName);
+          foreignKeyName = XSKHDBUtils.escapeArtifactName(foreignKeyName);
           for (int i = 0; i < fkColumns.length; i++) {
-            fkColumns[i] = XSKHDBUtils.escapeArtifactName(connection, fkColumns[i]);
+            fkColumns[i] = XSKHDBUtils.escapeArtifactName(fkColumns[i]);
           }
           for (int i = 0; i < referencedColumns.length; i++) {
-            referencedColumns[i] = XSKHDBUtils.escapeArtifactName(connection, referencedColumns[i]);
+            referencedColumns[i] = XSKHDBUtils.escapeArtifactName(referencedColumns[i]);
           }
           createTableBuilder.foreignKey(foreignKeyName, fkColumns, referencedTable, referencedColumns);
         }
@@ -125,7 +123,8 @@ public class XSKEntityCreateProcessor extends AbstractXSKProcessor<XSKDataStruct
       applyArtefactState(entityModel.getName(), entityModel.getLocation(), ENTITY_ARTEFACT, ArtefactState.SUCCESSFUL_CREATE, message);
     } catch (SQLException ex) {
       String message = String.format("Create entity [%s] skipped due to an error: %s", entityModel, ex.getMessage());
-      XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.XSK_ENTITY_PROCESSOR);
+      XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+          XSKCommonsConstants.XSK_ENTITY_PROCESSOR);
       applyArtefactState(entityModel.getName(), entityModel.getLocation(), ENTITY_ARTEFACT, ArtefactState.FAILED_CREATE, message);
     }
   }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityDropProcessor.java
@@ -11,16 +11,6 @@
  */
 package com.sap.xsk.hdb.ds.processors.entity;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
-import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sap.xsk.hdb.ds.artefacts.HDBDDEntitySynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureEntityModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintForeignKeyModel;
@@ -28,6 +18,14 @@ import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
 import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.utils.XSKHDBUtils;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Entity Drop Processor.
@@ -45,7 +43,7 @@ public class XSKEntityDropProcessor extends AbstractXSKProcessor<XSKDataStructur
    * @throws SQLException the SQL exception
    */
   public void execute(Connection connection, XSKDataStructureEntityModel entityModel) throws SQLException {
-    String tableName = XSKHDBUtils.escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel));
+    String tableName = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel));
     logger.info("Processing Drop Table: {}", tableName);
     if (SqlFactory.getNative(connection).exists(connection, tableName)) {
       String sql = SqlFactory.getNative(connection).select().column("COUNT(*)").from(tableName)
@@ -60,14 +58,17 @@ public class XSKEntityDropProcessor extends AbstractXSKProcessor<XSKDataStructur
               String errorMessage = String
                   .format("Drop operation for the non empty Table %s will not be executed. Delete all the records in the table first.",
                       tableName);
-              XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+              XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+                  XSKCommonsConstants.HDB_TABLE_PARSER);
               logger.error(errorMessage);
-              applyArtefactState(entityModel.getName(), entityModel.getLocation(), ENTITY_ARTEFACT, ArtefactState.FAILED_DELETE, errorMessage);
+              applyArtefactState(entityModel.getName(), entityModel.getLocation(), ENTITY_ARTEFACT, ArtefactState.FAILED_DELETE,
+                  errorMessage);
             }
           }
         }
       } catch (SQLException e) {
-        XSKCommonsUtils.logProcessorErrors(e.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+        XSKCommonsUtils.logProcessorErrors(e.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+            XSKCommonsConstants.HDB_TABLE_PARSER);
         logger.error(sql);
         logger.error(e.getMessage(), e);
         applyArtefactState(entityModel.getName(), entityModel.getLocation(), ENTITY_ARTEFACT, ArtefactState.FAILED_DELETE, e.getMessage());
@@ -78,12 +79,12 @@ public class XSKEntityDropProcessor extends AbstractXSKProcessor<XSKDataStructur
           String foreignKeyName = "FK_" + foreignKey.getName();
           String[] fkColumns = foreignKey.getColumns();
           String[] referencedColumns = foreignKey.getReferencedColumns();
-          foreignKeyName = XSKHDBUtils.escapeArtifactName(connection, foreignKeyName);
+          foreignKeyName = XSKHDBUtils.escapeArtifactName(foreignKeyName);
           for (int i = 0; i < fkColumns.length; i++) {
-            fkColumns[i] = XSKHDBUtils.escapeArtifactName(connection, fkColumns[i]);
+            fkColumns[i] = XSKHDBUtils.escapeArtifactName(fkColumns[i]);
           }
           for (int i = 0; i < referencedColumns.length; i++) {
-            referencedColumns[i] = XSKHDBUtils.escapeArtifactName(connection, referencedColumns[i]);
+            referencedColumns[i] = XSKHDBUtils.escapeArtifactName(referencedColumns[i]);
           }
           sql = SqlFactory.getNative(connection).drop().constraint(foreignKeyName).fromTable(tableName).build();
           try {
@@ -91,7 +92,8 @@ public class XSKEntityDropProcessor extends AbstractXSKProcessor<XSKDataStructur
             String message = String.format("Drop entity %s successfully", entityModel.getName());
             applyArtefactState(entityModel.getName(), entityModel.getLocation(), ENTITY_ARTEFACT, ArtefactState.SUCCESSFUL_DELETE, message);
           } catch (SQLException ex) {
-            XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.XSK_ENTITY_PROCESSOR);
+            XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+                XSKCommonsConstants.XSK_ENTITY_PROCESSOR);
             String message = String.format("Drop entity [%s] skipped due to an error: %s", entityModel, ex.getMessage());
             applyArtefactState(entityModel.getName(), entityModel.getLocation(), ENTITY_ARTEFACT, ArtefactState.FAILED_DELETE, message);
           }
@@ -105,7 +107,8 @@ public class XSKEntityDropProcessor extends AbstractXSKProcessor<XSKDataStructur
         applyArtefactState(entityModel.getName(), entityModel.getLocation(), ENTITY_ARTEFACT, ArtefactState.SUCCESSFUL_DELETE, message);
       } catch (SQLException ex) {
         String message = String.format("Drop entity [%s] skipped due to an error: %s", entityModel, ex.getMessage());
-        XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.XSK_ENTITY_PROCESSOR);
+        XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+            XSKCommonsConstants.XSK_ENTITY_PROCESSOR);
         applyArtefactState(entityModel.getName(), entityModel.getLocation(), ENTITY_ARTEFACT, ArtefactState.FAILED_DELETE, message);
       }
       return;

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityForeignKeysProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityForeignKeysProcessor.java
@@ -11,21 +11,19 @@
  */
 package com.sap.xsk.hdb.ds.processors.entity;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.List;
-
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.eclipse.dirigible.database.sql.builders.table.AlterTableBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureEntityModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintForeignKeyModel;
 import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
 import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.utils.XSKHDBUtils;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.builders.table.AlterTableBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Entity Create Processor.
@@ -52,7 +50,7 @@ public class XSKEntityForeignKeysProcessor extends AbstractXSKProcessor<XSKDataS
 
       String sourceTable = XSKHDBUtils.getTableName(entityModel);
       String name = "FK_" + sourceTable + "_" + tableName;
-      sourceTable = XSKHDBUtils.escapeArtifactName(connection, sourceTable);
+      sourceTable = XSKHDBUtils.escapeArtifactName(sourceTable);
 
       boolean existing = SqlFactory.getNative(connection).exists(connection, sourceTable);
       if (existing) {
@@ -63,11 +61,13 @@ public class XSKEntityForeignKeysProcessor extends AbstractXSKProcessor<XSKDataS
         try {
           executeSql(sql, connection);
         } catch (SQLException ex) {
-          XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.XSK_ENTITY_PROCESSOR);
+          XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+              XSKCommonsConstants.XSK_ENTITY_PROCESSOR);
         }
       } else {
         String reason = "Table does not exist - " + sourceTable;
-        XSKCommonsUtils.logProcessorErrors(reason, XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(), XSKCommonsConstants.HDB_ENTITY_PROCESSOR);
+        XSKCommonsUtils.logProcessorErrors(reason, XSKCommonsConstants.PROCESSOR_ERROR, entityModel.getLocation(),
+            XSKCommonsConstants.HDB_ENTITY_PROCESSOR);
         logger.error(reason);
         throw new SQLException(reason);
       }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityUpdateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/entity/XSKEntityUpdateProcessor.java
@@ -11,17 +11,15 @@
  */
 package com.sap.xsk.hdb.ds.processors.entity;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sap.xsk.hdb.ds.api.IXSKHdbProcessor;
 import com.sap.xsk.hdb.ds.model.hdbdd.XSKDataStructureEntityModel;
 import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
 import com.sap.xsk.utils.XSKHDBUtils;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class XSKEntityUpdateProcessor extends AbstractXSKProcessor<XSKDataStructureEntityModel> {
 
@@ -39,7 +37,7 @@ public class XSKEntityUpdateProcessor extends AbstractXSKProcessor<XSKDataStruct
    */
   public void execute(Connection connection, XSKDataStructureEntityModel entityModel)
       throws SQLException {
-    String tableName = XSKHDBUtils.escapeArtifactName(connection, XSKHDBUtils.getTableName(entityModel));
+    String tableName = XSKHDBUtils.escapeArtifactName(XSKHDBUtils.getTableName(entityModel));
     logger.info("Processing Update Entity: {}", tableName);
     if (SqlFactory.getNative(connection).exists(connection, tableName)) {
       if (SqlFactory.getNative(connection).count(connection, tableName) == 0) {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbschema/HDBSchemaDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbschema/HDBSchemaDropProcessor.java
@@ -11,9 +11,14 @@
  */
 package com.sap.xsk.hdb.ds.processors.hdbschema;
 
+import com.sap.xsk.hdb.ds.artefacts.HDBSchemaSynchronizationArtefactType;
+import com.sap.xsk.hdb.ds.model.hdbschema.XSKDataStructureHDBSchemaModel;
+import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
+import com.sap.xsk.utils.XSKCommonsConstants;
+import com.sap.xsk.utils.XSKCommonsUtils;
+import com.sap.xsk.utils.XSKHDBUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
-
 import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
 import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
 import org.eclipse.dirigible.database.sql.ISqlDialect;
@@ -21,13 +26,6 @@ import org.eclipse.dirigible.database.sql.SqlFactory;
 import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.sap.xsk.hdb.ds.artefacts.HDBSchemaSynchronizationArtefactType;
-import com.sap.xsk.hdb.ds.model.hdbschema.XSKDataStructureHDBSchemaModel;
-import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
-import com.sap.xsk.utils.XSKCommonsConstants;
-import com.sap.xsk.utils.XSKCommonsUtils;
-import com.sap.xsk.utils.XSKHDBUtils;
 
 public class HDBSchemaDropProcessor extends AbstractXSKProcessor<XSKDataStructureHDBSchemaModel> {
 
@@ -41,12 +39,13 @@ public class HDBSchemaDropProcessor extends AbstractXSKProcessor<XSKDataStructur
     ISqlDialect dialect = SqlFactory.deriveDialect(connection);
     if (!(dialect.getClass().equals(HanaSqlDialect.class))) {
       String errorMessage = String.format("%s does not support Schema", dialect.getDatabaseName(connection));
-      XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, hdbSchema.getLocation(), XSKCommonsConstants.HDB_SCHEMA_PARSER);
+      XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, hdbSchema.getLocation(),
+          XSKCommonsConstants.HDB_SCHEMA_PARSER);
       applyArtefactState(hdbSchema.getName(), hdbSchema.getLocation(), SCHEMA_ARTEFACT, ArtefactState.FAILED_DELETE, errorMessage);
       throw new IllegalStateException(errorMessage);
     } else {
       if (SqlFactory.getNative(connection).exists(connection, hdbSchema.getSchema(), DatabaseArtifactTypes.SCHEMA)) {
-        String schemaName = XSKHDBUtils.escapeArtifactName(connection, hdbSchema.getSchema());
+        String schemaName = XSKHDBUtils.escapeArtifactName(hdbSchema.getSchema());
         String sql = SqlFactory.getNative(connection).drop().schema(schemaName).build();
         try {
           executeSql(sql, connection);
@@ -54,7 +53,8 @@ public class HDBSchemaDropProcessor extends AbstractXSKProcessor<XSKDataStructur
           applyArtefactState(hdbSchema.getName(), hdbSchema.getLocation(), SCHEMA_ARTEFACT, ArtefactState.SUCCESSFUL_DELETE, message);
         } catch (SQLException ex) {
           String message = String.format("Drop schema[%s] skipped due to an error: %s", hdbSchema, ex.getMessage());
-          XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, hdbSchema.getLocation(), XSKCommonsConstants.HDB_SCHEMA_PARSER);
+          XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, hdbSchema.getLocation(),
+              XSKCommonsConstants.HDB_SCHEMA_PARSER);
           applyArtefactState(hdbSchema.getName(), hdbSchema.getLocation(), SCHEMA_ARTEFACT, ArtefactState.FAILED_DELETE, message);
         }
       } else {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbsequence/XSKHDBSequenceCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbsequence/XSKHDBSequenceCreateProcessor.java
@@ -11,16 +11,6 @@
  */
 package com.sap.xsk.hdb.ds.processors.hdbsequence;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
-import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
-import org.eclipse.dirigible.database.sql.ISqlDialect;
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sap.xsk.hdb.ds.artefacts.HDBSequenceSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.hdbsequence.XSKDataStructureHDBSequenceModel;
 import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
@@ -28,6 +18,14 @@ import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.utils.XSKConstants;
 import com.sap.xsk.utils.XSKHDBUtils;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class XSKHDBSequenceCreateProcessor extends AbstractXSKProcessor<XSKDataStructureHDBSequenceModel> {
 
@@ -37,7 +35,7 @@ public class XSKHDBSequenceCreateProcessor extends AbstractXSKProcessor<XSKDataS
 
   @Override
   public void execute(Connection connection, XSKDataStructureHDBSequenceModel hdbSequenceModel) throws SQLException {
-    String hdbSequenceName = XSKHDBUtils.escapeArtifactName(connection, hdbSequenceModel.getName(), hdbSequenceModel.getSchema());
+    String hdbSequenceName = XSKHDBUtils.escapeArtifactName(hdbSequenceModel.getName(), hdbSequenceModel.getSchema());
     logger.info("Processing Create HdbSequence: " + hdbSequenceName);
     String sql = null;
     switch (hdbSequenceModel.getDBContentType()) {
@@ -52,8 +50,10 @@ public class XSKHDBSequenceCreateProcessor extends AbstractXSKProcessor<XSKDataS
           break;
         } else {
           String errorMessage = String.format("Sequences are not supported for %s !", dialect.getDatabaseName(connection));
-          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(), XSKCommonsConstants.HDB_SEQUENCE_PARSER);
-          applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_CREATE, errorMessage);
+          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(),
+              XSKCommonsConstants.HDB_SEQUENCE_PARSER);
+          applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_CREATE,
+              errorMessage);
           throw new IllegalStateException(errorMessage);
         }
       }
@@ -61,11 +61,14 @@ public class XSKHDBSequenceCreateProcessor extends AbstractXSKProcessor<XSKDataS
     try {
       executeSql(sql, connection);
       String message = String.format("Create sequence %s successfully", hdbSequenceModel.getName());
-      applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.SUCCESSFUL_CREATE, message);
+      applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.SUCCESSFUL_CREATE,
+          message);
     } catch (SQLException ex) {
       String message = String.format("Create sequence [%s] skipped due to an error: %s", hdbSequenceModel.getName(), ex.getMessage());
-      XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(), XSKCommonsConstants.HDB_SEQUENCE_PARSER);
-      applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_CREATE, message);
+      XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(),
+          XSKCommonsConstants.HDB_SEQUENCE_PARSER);
+      applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_CREATE,
+          message);
     }
   }
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbsequence/XSKHDBSequenceDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbsequence/XSKHDBSequenceDropProcessor.java
@@ -11,9 +11,15 @@
  */
 package com.sap.xsk.hdb.ds.processors.hdbsequence;
 
+import com.sap.xsk.hdb.ds.artefacts.HDBSequenceSynchronizationArtefactType;
+import com.sap.xsk.hdb.ds.model.hdbsequence.XSKDataStructureHDBSequenceModel;
+import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
+import com.sap.xsk.utils.XSKCommonsConstants;
+import com.sap.xsk.utils.XSKCommonsUtils;
+import com.sap.xsk.utils.XSKConstants;
+import com.sap.xsk.utils.XSKHDBUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
-
 import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
 import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
 import org.eclipse.dirigible.database.sql.ISqlDialect;
@@ -22,14 +28,6 @@ import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sap.xsk.hdb.ds.artefacts.HDBSequenceSynchronizationArtefactType;
-import com.sap.xsk.hdb.ds.model.hdbsequence.XSKDataStructureHDBSequenceModel;
-import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
-import com.sap.xsk.utils.XSKCommonsConstants;
-import com.sap.xsk.utils.XSKCommonsUtils;
-import com.sap.xsk.utils.XSKConstants;
-import com.sap.xsk.utils.XSKHDBUtils;
-
 public class XSKHDBSequenceDropProcessor extends AbstractXSKProcessor<XSKDataStructureHDBSequenceModel> {
 
   private static final Logger logger = LoggerFactory.getLogger(XSKHDBSequenceDropProcessor.class);
@@ -37,7 +35,7 @@ public class XSKHDBSequenceDropProcessor extends AbstractXSKProcessor<XSKDataStr
 
   @Override
   public void execute(Connection connection, XSKDataStructureHDBSequenceModel hdbSequenceModel) throws SQLException {
-    String hdbSequenceName = XSKHDBUtils.escapeArtifactName(connection, hdbSequenceModel.getName(), hdbSequenceModel.getSchema());
+    String hdbSequenceName = XSKHDBUtils.escapeArtifactName(hdbSequenceModel.getName(), hdbSequenceModel.getSchema());
     logger.info("Processing Drop HdbSequence: " + hdbSequenceName);
 
     if (SqlFactory.getNative(connection).exists(connection, hdbSequenceName, DatabaseArtifactTypes.SEQUENCE)) {
@@ -54,8 +52,10 @@ public class XSKHDBSequenceDropProcessor extends AbstractXSKProcessor<XSKDataStr
             break;
           } else {
             String errorMessage = String.format("Sequences are not supported for %s !", dialect.getDatabaseName(connection));
-            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(), XSKCommonsConstants.HDB_SEQUENCE_PARSER);
-            applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_DELETE, errorMessage);
+            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(),
+                XSKCommonsConstants.HDB_SEQUENCE_PARSER);
+            applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_DELETE,
+                errorMessage);
             throw new IllegalStateException(errorMessage);
           }
         }
@@ -63,16 +63,20 @@ public class XSKHDBSequenceDropProcessor extends AbstractXSKProcessor<XSKDataStr
       try {
         executeSql(sql, connection);
         String message = String.format("Drop sequence %s successfully", hdbSequenceModel.getName());
-        applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.SUCCESSFUL_DELETE, message);
+        applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.SUCCESSFUL_DELETE,
+            message);
       } catch (SQLException ex) {
         String message = String.format("Drop sequence [%s] skipped due to an error: %s", hdbSequenceModel.getName(), ex.getMessage());
-        XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(), XSKCommonsConstants.HDB_SEQUENCE_PARSER);
-        applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_DELETE, message);
+        XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(),
+            XSKCommonsConstants.HDB_SEQUENCE_PARSER);
+        applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_DELETE,
+            message);
       }
     } else {
       String warningMessage = String.format("Sequence [%s] does not exists during the drop process", hdbSequenceModel.getName());
       logger.warn(warningMessage);
-      applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_DELETE, warningMessage);
+      applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_DELETE,
+          warningMessage);
     }
   }
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbsequence/XSKHDBSequenceUpdateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbsequence/XSKHDBSequenceUpdateProcessor.java
@@ -12,16 +12,6 @@
 package com.sap.xsk.hdb.ds.processors.hdbsequence;
 
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
-import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
-import org.eclipse.dirigible.database.sql.ISqlDialect;
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sap.xsk.hdb.ds.artefacts.HDBSequenceSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.hdbsequence.XSKDataStructureHDBSequenceModel;
 import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
@@ -29,6 +19,14 @@ import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.utils.XSKConstants;
 import com.sap.xsk.utils.XSKHDBUtils;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class XSKHDBSequenceUpdateProcessor extends AbstractXSKProcessor<XSKDataStructureHDBSequenceModel> {
 
@@ -37,7 +35,7 @@ public class XSKHDBSequenceUpdateProcessor extends AbstractXSKProcessor<XSKDataS
 
   @Override
   public void execute(Connection connection, XSKDataStructureHDBSequenceModel hdbSequenceModel) throws SQLException {
-    String hdbSequenceName = XSKHDBUtils.escapeArtifactName(connection, hdbSequenceModel.getName(), hdbSequenceModel.getSchema());
+    String hdbSequenceName = XSKHDBUtils.escapeArtifactName(hdbSequenceModel.getName(), hdbSequenceModel.getSchema());
     logger.info("Processing Update HdbSequence: " + hdbSequenceName);
 
     String sql = null;
@@ -53,8 +51,10 @@ public class XSKHDBSequenceUpdateProcessor extends AbstractXSKProcessor<XSKDataS
           break;
         } else {
           String errorMessage = String.format("Sequences are not supported for %s !", dialect.getDatabaseName(connection));
-          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(), XSKCommonsConstants.HDB_SEQUENCE_PARSER);
-          applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_UPDATE, errorMessage);
+          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(),
+              XSKCommonsConstants.HDB_SEQUENCE_PARSER);
+          applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_UPDATE,
+              errorMessage);
           throw new IllegalStateException(errorMessage);
         }
       }
@@ -62,11 +62,14 @@ public class XSKHDBSequenceUpdateProcessor extends AbstractXSKProcessor<XSKDataS
     try {
       executeSql(sql, connection);
       String message = String.format("Update sequence %s successfully", hdbSequenceModel.getName());
-      applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.SUCCESSFUL_UPDATE, message);
+      applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.SUCCESSFUL_UPDATE,
+          message);
     } catch (SQLException ex) {
       String message = String.format("Update sequence [%s] skipped due to an error: %s", hdbSequenceModel.getName(), ex.getMessage());
-      XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(), XSKCommonsConstants.HDB_SEQUENCE_PARSER);
-      applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_UPDATE, message);
+      XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, hdbSequenceModel.getLocation(),
+          XSKCommonsConstants.HDB_SEQUENCE_PARSER);
+      applyArtefactState(hdbSequenceModel.getName(), hdbSequenceModel.getLocation(), SEQUENCE_ARTEFACT, ArtefactState.FAILED_UPDATE,
+          message);
     }
   }
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbstructure/XSKTableTypeCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbstructure/XSKTableTypeCreateProcessor.java
@@ -13,20 +13,6 @@ package com.sap.xsk.hdb.ds.processors.hdbstructure;
 
 import static java.text.MessageFormat.format;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Map;
-
-import org.eclipse.dirigible.database.sql.DataType;
-import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
-import org.eclipse.dirigible.database.sql.ISqlDialect;
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.eclipse.dirigible.database.sql.builders.tableType.CreateTableTypeBuilder;
-import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableColumnModel;
 import com.sap.xsk.hdb.ds.model.hdbtabletype.XSKDataStructureHDBTableTypeModel;
@@ -37,6 +23,18 @@ import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.utils.XSKConstants;
 import com.sap.xsk.utils.XSKHDBUtils;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.dirigible.database.sql.DataType;
+import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.builders.tableType.CreateTableTypeBuilder;
+import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class XSKTableTypeCreateProcessor extends AbstractXSKProcessor<XSKDataStructureHDBTableTypeModel> {
 
@@ -57,7 +55,7 @@ public class XSKTableTypeCreateProcessor extends AbstractXSKProcessor<XSKDataStr
     logger.info("Processing Create Table Type: " + tableTypeModel.getName());
 
     String tableTypeNameWithoutSchema = tableTypeModel.getName();
-    String tableTypeNameWithSchema = XSKHDBUtils.escapeArtifactName(connection, tableTypeNameWithoutSchema, tableTypeModel.getSchema());
+    String tableTypeNameWithSchema = XSKHDBUtils.escapeArtifactName(tableTypeNameWithoutSchema, tableTypeModel.getSchema());
     List<XSKDataStructureHDBTableColumnModel> columns = tableTypeModel.getColumns();
 
     if (!SqlFactory.getNative(connection)
@@ -66,7 +64,7 @@ public class XSKTableTypeCreateProcessor extends AbstractXSKProcessor<XSKDataStr
       CreateTableTypeBuilder createTableTypeBuilder = SqlFactory.getNative(connection).create().tableType(tableTypeNameWithSchema);
 
       for (XSKDataStructureHDBTableColumnModel columnModel : columns) {
-        String name = XSKHDBUtils.escapeArtifactName(connection, columnModel.getName());
+        String name = XSKHDBUtils.escapeArtifactName(columnModel.getName());
         DataType type = DataType.valueOf(columnModel.getType());
         createTableTypeBuilder
             .column(name, type, columnModel.isPrimaryKey(), columnModel.isNullable(), this.getColumnModelArgs(columnModel));
@@ -84,7 +82,8 @@ public class XSKTableTypeCreateProcessor extends AbstractXSKProcessor<XSKDataStr
             break;
           } else {
             String errorMessage = String.format("Table Types are not supported for %s !", dialect.getDatabaseName(connection));
-            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableTypeModel.getLocation(), XSKCommonsConstants.HDB_TABLE_TYPE_PARSER);
+            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableTypeModel.getLocation(),
+                XSKCommonsConstants.HDB_TABLE_TYPE_PARSER);
             throw new IllegalStateException(errorMessage);
           }
         }
@@ -92,7 +91,8 @@ public class XSKTableTypeCreateProcessor extends AbstractXSKProcessor<XSKDataStr
       try {
         executeSql(sql, connection);
       } catch (SQLException ex) {
-        XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, tableTypeModel.getLocation(), XSKCommonsConstants.HDB_TABLE_TYPE_PARSER);
+        XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, tableTypeModel.getLocation(),
+            XSKCommonsConstants.HDB_TABLE_TYPE_PARSER);
       }
     } else {
       logger.warn(format("Table Type [{0}] already exists during the create process", tableTypeNameWithoutSchema));

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbstructure/XSKTableTypeDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/hdbstructure/XSKTableTypeDropProcessor.java
@@ -59,7 +59,7 @@ public class XSKTableTypeDropProcessor extends AbstractXSKProcessor<XSKDataStruc
   }
 
   String escapeTableTypeName(Connection connection, XSKDataStructureHDBTableTypeModel tableTypeModel) {
-    return XSKHDBUtils.escapeArtifactName(connection, tableTypeModel.getName(), tableTypeModel.getSchema());
+    return XSKHDBUtils.escapeArtifactName(tableTypeModel.getName(), tableTypeModel.getSchema());
   }
 
   String getDropTableTypeSQL(Connection connection, String tableTypeName) throws IllegalStateException {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymCreateProcessor.java
@@ -11,9 +11,14 @@
  */
 package com.sap.xsk.hdb.ds.processors.synonym;
 
+import com.sap.xsk.hdb.ds.artefacts.HDBSynonymSynchronizationArtefactType;
+import com.sap.xsk.hdb.ds.model.hdbsynonym.XSKDataStructureHDBSynonymModel;
+import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
+import com.sap.xsk.utils.XSKCommonsConstants;
+import com.sap.xsk.utils.XSKCommonsUtils;
+import com.sap.xsk.utils.XSKHDBUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
-
 import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
 import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
 import org.eclipse.dirigible.database.sql.ISqlDialect;
@@ -21,13 +26,6 @@ import org.eclipse.dirigible.database.sql.SqlFactory;
 import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.sap.xsk.hdb.ds.artefacts.HDBSynonymSynchronizationArtefactType;
-import com.sap.xsk.hdb.ds.model.hdbsynonym.XSKDataStructureHDBSynonymModel;
-import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
-import com.sap.xsk.utils.XSKCommonsConstants;
-import com.sap.xsk.utils.XSKCommonsUtils;
-import com.sap.xsk.utils.XSKHDBUtils;
 
 
 public class HDBSynonymCreateProcessor extends AbstractXSKProcessor<XSKDataStructureHDBSynonymModel> {
@@ -48,10 +46,10 @@ public class HDBSynonymCreateProcessor extends AbstractXSKProcessor<XSKDataStruc
     synonymModel.getSynonymDefinitions().forEach((key, value) -> {
       logger.info("Processing Create Synonym: " + key);
 
-      String synonymName = (value.getSynonymSchema() != null) ? (XSKHDBUtils.escapeArtifactName(connection, key, value.getSynonymSchema()))
-          : (XSKHDBUtils.escapeArtifactName(connection, key));
+      String synonymName = (value.getSynonymSchema() != null) ? (XSKHDBUtils.escapeArtifactName(key, value.getSynonymSchema()))
+          : (XSKHDBUtils.escapeArtifactName(key));
       String targetObjectName = XSKHDBUtils
-          .escapeArtifactName(connection, value.getTarget().getObject(),
+          .escapeArtifactName(value.getTarget().getObject(),
               value.getTarget().getSchema());
       try {
         String synonymSchema = null != value.getSynonymSchema() ? value.getSynonymSchema() : connection.getMetaData().getUserName();
@@ -59,7 +57,8 @@ public class HDBSynonymCreateProcessor extends AbstractXSKProcessor<XSKDataStruc
           ISqlDialect dialect = SqlFactory.deriveDialect(connection);
           if (!(dialect.getClass().equals(HanaSqlDialect.class))) {
             String errorMessage = String.format("Synonyms are not supported for %s !", dialect.getDatabaseName(connection));
-            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, synonymModel.getLocation(), XSKCommonsConstants.HDB_SYNONYM_PARSER);
+            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, synonymModel.getLocation(),
+                XSKCommonsConstants.HDB_SYNONYM_PARSER);
             applyArtefactState(synonymName, synonymModel.getLocation(), SYNONYM_ARTEFACT, ArtefactState.FAILED_CREATE, errorMessage);
             throw new IllegalStateException(errorMessage);
           } else {
@@ -70,7 +69,8 @@ public class HDBSynonymCreateProcessor extends AbstractXSKProcessor<XSKDataStruc
               applyArtefactState(synonymName, synonymModel.getLocation(), SYNONYM_ARTEFACT, ArtefactState.SUCCESSFUL_CREATE, message);
             } catch (SQLException ex) {
               String errorMessage = String.format("Create synonym [%s] skipped due to an error: %s", synonymName, ex.getMessage());
-              XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, synonymModel.getLocation(), XSKCommonsConstants.HDB_SYNONYM_PARSER);
+              XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, synonymModel.getLocation(),
+                  XSKCommonsConstants.HDB_SYNONYM_PARSER);
               applyArtefactState(synonymName, synonymModel.getLocation(), SYNONYM_ARTEFACT, ArtefactState.FAILED_CREATE, errorMessage);
             }
           }

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/synonym/HDBSynonymDropProcessor.java
@@ -42,8 +42,8 @@ public class HDBSynonymDropProcessor extends AbstractXSKProcessor<XSKDataStructu
   public void execute(Connection connection, XSKDataStructureHDBSynonymModel synonymModel) {
     synonymModel.getSynonymDefinitions().forEach((key, value) -> {
 
-      String synonymName = (value.getSynonymSchema() != null) ? XSKHDBUtils.escapeArtifactName(connection, key, value.getSynonymSchema())
-          : XSKHDBUtils.escapeArtifactName(connection, key);
+      String synonymName = (value.getSynonymSchema() != null) ? XSKHDBUtils.escapeArtifactName(key, value.getSynonymSchema())
+          : XSKHDBUtils.escapeArtifactName(key);
       try {
         if (SqlFactory.getNative(connection).exists(connection, value.getSynonymSchema(), key, DatabaseArtifactTypes.SYNONYM)) {
           String sql = SqlFactory.getNative(connection).drop().synonym(synonymName).build();

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/XSKTableAlterHandler.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/XSKTableAlterHandler.java
@@ -9,12 +9,11 @@
  * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and XSK contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.sap.xsk.hdb.ds.processors.table.utils;
+package com.sap.xsk.hdb.ds.processors.table;
 
 import com.sap.xsk.hdb.ds.artefacts.HDBTableSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableColumnModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableModel;
-import com.sap.xsk.hdb.ds.processors.table.TableBuilder;
 import com.sap.xsk.hdb.ds.synchronizer.XSKDataStructuresSynchronizer;
 import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/XSKTableAlterProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/XSKTableAlterProcessor.java
@@ -11,12 +11,10 @@
  */
 package com.sap.xsk.hdb.ds.processors.table;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableModel;
 import com.sap.xsk.hdb.ds.processors.AbstractXSKProcessor;
-import com.sap.xsk.hdb.ds.processors.table.utils.XSKTableAlterHandler;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 public class XSKTableAlterProcessor extends AbstractXSKProcessor<XSKDataStructureHDBTableModel> {
 

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/XSKTableDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/XSKTableDropProcessor.java
@@ -11,19 +11,6 @@
  */
 package com.sap.xsk.hdb.ds.processors.table;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Map;
-
-import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
-import org.eclipse.dirigible.database.sql.ISqlDialect;
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.artefacts.HDBTableSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintForeignKeyModel;
@@ -35,6 +22,17 @@ import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.utils.XSKConstants;
 import com.sap.xsk.utils.XSKHDBUtils;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Table Drop Processor.
@@ -57,7 +55,7 @@ public class XSKTableDropProcessor extends AbstractXSKProcessor<XSKDataStructure
       throws SQLException {
     logger.info("Processing Drop Table: " + tableModel.getName());
 
-    String tableName = XSKHDBUtils.escapeArtifactName(connection, tableModel.getName(), tableModel.getSchema());
+    String tableName = XSKHDBUtils.escapeArtifactName(tableModel.getName(), tableModel.getSchema());
     String tableNameWithoutSchema = tableModel.getName();
 
     //Drop public synonym
@@ -80,7 +78,8 @@ public class XSKTableDropProcessor extends AbstractXSKProcessor<XSKDataStructure
             break;
           } else {
             String errorMessage = String.format("Tables are not supported for %s !", dialect.getDatabaseName(connection));
-            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(),
+                XSKCommonsConstants.HDB_TABLE_PARSER);
             applyArtefactState(tableModel.getName(), tableModel.getLocation(), TABLE_ARTEFACT, ArtefactState.FAILED_DELETE, errorMessage);
             throw new IllegalStateException(errorMessage);
           }
@@ -98,7 +97,8 @@ public class XSKTableDropProcessor extends AbstractXSKProcessor<XSKDataStructure
             String errorMessage = String
                 .format("Drop operation for the non empty Table %s will not be executed. Delete all the records in the table first.",
                     tableName);
-            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(),
+                XSKCommonsConstants.HDB_TABLE_PARSER);
             logger.error(errorMessage);
             applyArtefactState(tableModel.getName(), tableModel.getLocation(), TABLE_ARTEFACT, ArtefactState.FAILED_DELETE, errorMessage);
             return;
@@ -106,7 +106,8 @@ public class XSKTableDropProcessor extends AbstractXSKProcessor<XSKDataStructure
         }
       } catch (SQLException e) {
         String errorMessage = String.format("Drop table[%s] skipped due to an error: {%s}", tableModel, e.getMessage());
-        XSKCommonsUtils.logProcessorErrors(e.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+        XSKCommonsUtils.logProcessorErrors(e.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(),
+            XSKCommonsConstants.HDB_TABLE_PARSER);
         logger.error(sql);
         logger.error(e.getMessage(), e);
         applyArtefactState(tableModel.getName(), tableModel.getLocation(), TABLE_ARTEFACT, ArtefactState.FAILED_DELETE, errorMessage);
@@ -139,7 +140,8 @@ public class XSKTableDropProcessor extends AbstractXSKProcessor<XSKDataStructure
       applyArtefactState(tableModel.getName(), tableModel.getLocation(), TABLE_ARTEFACT, ArtefactState.SUCCESSFUL_DELETE, message);
     } catch (SQLException e) {
       String message = String.format("Drop table[%s] skipped due to an error: {%s}", tableModel, e.getMessage());
-      XSKCommonsUtils.logProcessorErrors(e.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+      XSKCommonsUtils.logProcessorErrors(e.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(),
+          XSKCommonsConstants.HDB_TABLE_PARSER);
       logger.error(sql);
       logger.error(e.getMessage(), e);
       applyArtefactState(tableModel.getName(), tableModel.getLocation(), TABLE_ARTEFACT, ArtefactState.FAILED_DELETE, message);

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/utils/XSKTableAlterHandler.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/table/utils/XSKTableAlterHandler.java
@@ -107,12 +107,14 @@ public class XSKTableAlterHandler {
 
         if (!isNullable) {
           String errorMessage = String.format(INCOMPATIBLE_CHANGE_OF_TABLE, tableName, name, "NOT NULL");
-          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(),
+              XSKCommonsConstants.HDB_TABLE_PARSER);
           throw new SQLException(errorMessage);
         }
         if (isPrimaryKey) {
           String errorMessage = String.format(INCOMPATIBLE_CHANGE_OF_TABLE, tableName, name, "PRIMARY KEY");
-          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+          XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(),
+              XSKCommonsConstants.HDB_TABLE_PARSER);
           throw new SQLException(errorMessage);
         }
 
@@ -121,8 +123,10 @@ public class XSKTableAlterHandler {
       } else if (!dbColumnTypes.get(name).equals(type.toString())) {
         String errorMessage = String
             .format(INCOMPATIBLE_CHANGE_OF_TABLE, tableName, name, "of type " + dbColumnTypes.get(name) + " to be changed to " + type);
-        XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
-        dataStructuresSynchronizer.applyArtefactState(tableModel.getName(), tableModel.getLocation(), TABLE_ARTEFACT, ArtefactState.FAILED_UPDATE, errorMessage);
+        XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(),
+            XSKCommonsConstants.HDB_TABLE_PARSER);
+        dataStructuresSynchronizer.applyArtefactState(tableModel.getName(), tableModel.getLocation(), TABLE_ARTEFACT,
+            ArtefactState.FAILED_UPDATE, errorMessage);
         throw new SQLException(errorMessage);
       }
     }
@@ -177,7 +181,8 @@ public class XSKTableAlterHandler {
       if (!dbColumnTypes.get(name).equals(type.toString())) {
         String errorMessage = String
             .format(INCOMPATIBLE_CHANGE_OF_TABLE, tableName, name, "of type " + dbColumnTypes.get(name) + " to be changed to" + type);
-        XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+        XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(),
+            XSKCommonsConstants.HDB_TABLE_PARSER);
         throw new SQLException(errorMessage);
       }
       AlterTableBuilder alterTableBuilder = SqlFactory.getNative(connection).alter().table(tableName);
@@ -199,7 +204,7 @@ public class XSKTableAlterHandler {
       dropExistingIndex(connection, stmt, droppedIndices, rsIndeces);
     }
 
-    XSKTableEscapeService escapeService = new XSKTableEscapeService(connection, this.tableModel);
+    TableSQLBuilder escapeService = new TableSQLBuilder(connection, this.tableModel);
 
     escapeService.escapeTableBuilderUniqueIndices(alterTableBuilder);
     executeAlterBuilder(connection, alterTableBuilder);
@@ -221,7 +226,8 @@ public class XSKTableAlterHandler {
     if (!isPKListUnchanged) {
       String errorMessage = String
           .format("Incompatible change of table [%s] by trying to change its primary key list", this.tableModel.getName());
-      XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+      XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, tableModel.getLocation(),
+          XSKCommonsConstants.HDB_TABLE_PARSER);
       throw new SQLException(errorMessage);
     }
   }
@@ -259,13 +265,16 @@ public class XSKTableAlterHandler {
       try {
         statement.executeUpdate();
         String messageSuccess = String.format("Update table %s successfully", this.tableModel.getName());
-        dataStructuresSynchronizer.applyArtefactState(this.tableModel.getName(), this.tableModel.getLocation(), TABLE_ARTEFACT, ArtefactState.SUCCESSFUL_UPDATE, messageSuccess);
+        dataStructuresSynchronizer.applyArtefactState(this.tableModel.getName(), this.tableModel.getLocation(), TABLE_ARTEFACT,
+            ArtefactState.SUCCESSFUL_UPDATE, messageSuccess);
       } catch (SQLException e) {
         logger.error(sql);
         logger.error(e.getMessage(), e);
-        XSKCommonsUtils.logProcessorErrors(e.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, this.tableModel.getLocation(), XSKCommonsConstants.HDB_TABLE_PARSER);
+        XSKCommonsUtils.logProcessorErrors(e.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, this.tableModel.getLocation(),
+            XSKCommonsConstants.HDB_TABLE_PARSER);
         String messageFail = String.format("Update table [%s] skipped due to an error: {%s}", this.tableModel, e.getMessage());
-        dataStructuresSynchronizer.applyArtefactState(this.tableModel.getName(), this.tableModel.getLocation(), TABLE_ARTEFACT, ArtefactState.FAILED_UPDATE, messageFail);
+        dataStructuresSynchronizer.applyArtefactState(this.tableModel.getName(), this.tableModel.getLocation(), TABLE_ARTEFACT,
+            ArtefactState.FAILED_UPDATE, messageFail);
         throw new SQLException(e.getMessage(), e);
       } finally {
         if (statement != null) {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/view/XSKViewCreateProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/view/XSKViewCreateProcessor.java
@@ -11,18 +11,6 @@
  */
 package com.sap.xsk.hdb.ds.processors.view;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Map;
-
-import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
-import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
-import org.eclipse.dirigible.database.sql.ISqlDialect;
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.artefacts.HDBViewSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.hdbview.XSKDataStructureHDBViewModel;
@@ -33,6 +21,16 @@ import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.utils.XSKConstants;
 import com.sap.xsk.utils.XSKHDBUtils;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
+import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.eclipse.dirigible.database.sql.dialects.hana.HanaSqlDialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The View Create Processor.
@@ -54,7 +52,7 @@ public class XSKViewCreateProcessor extends AbstractXSKProcessor<XSKDataStructur
   public void execute(Connection connection, XSKDataStructureHDBViewModel viewModel)
       throws SQLException {
     logger.info("Processing Create View: " + viewModel.getName());
-    String viewNameWithSchema = XSKHDBUtils.escapeArtifactName(connection, viewModel.getName(), viewModel.getSchema());
+    String viewNameWithSchema = XSKHDBUtils.escapeArtifactName(viewModel.getName(), viewModel.getSchema());
 
     if (!SqlFactory.getNative(connection).exists(connection, viewNameWithSchema, DatabaseArtifactTypes.VIEW)) {
       String sql = null;
@@ -70,7 +68,8 @@ public class XSKViewCreateProcessor extends AbstractXSKProcessor<XSKDataStructur
             break;
           } else {
             String errorMessage = String.format("Views are not supported for %s !", dialect.getDatabaseName(connection));
-            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, viewModel.getLocation(), XSKCommonsConstants.HDB_VIEW_PARSER);
+            XSKCommonsUtils.logProcessorErrors(errorMessage, XSKCommonsConstants.PROCESSOR_ERROR, viewModel.getLocation(),
+                XSKCommonsConstants.HDB_VIEW_PARSER);
             applyArtefactState(viewModel.getName(), viewModel.getLocation(), VIEW_ARTEFACT, ArtefactState.FAILED_CREATE, errorMessage);
             throw new IllegalStateException(errorMessage);
           }
@@ -82,7 +81,8 @@ public class XSKViewCreateProcessor extends AbstractXSKProcessor<XSKDataStructur
         applyArtefactState(viewModel.getName(), viewModel.getLocation(), VIEW_ARTEFACT, ArtefactState.SUCCESSFUL_CREATE, message);
       } catch (SQLException ex) {
         String errorMessage = String.format("Create view [%s] skipped due to an error: %s", viewModel.getName(), ex.getMessage());
-        XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, viewModel.getLocation(), XSKCommonsConstants.HDB_VIEW_PARSER);
+        XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, viewModel.getLocation(),
+            XSKCommonsConstants.HDB_VIEW_PARSER);
         applyArtefactState(viewModel.getName(), viewModel.getLocation(), VIEW_ARTEFACT, ArtefactState.FAILED_CREATE, errorMessage);
       }
     } else {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/view/XSKViewDropProcessor.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/processors/view/XSKViewDropProcessor.java
@@ -11,16 +11,6 @@
  */
 package com.sap.xsk.hdb.ds.processors.view;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Map;
-
-import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
-import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sap.xsk.hdb.ds.api.IXSKDataStructureModel;
 import com.sap.xsk.hdb.ds.artefacts.HDBViewSynchronizationArtefactType;
 import com.sap.xsk.hdb.ds.model.hdbview.XSKDataStructureHDBViewModel;
@@ -30,6 +20,14 @@ import com.sap.xsk.hdb.ds.service.manager.IXSKDataStructureManager;
 import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.utils.XSKHDBUtils;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+import org.eclipse.dirigible.core.scheduler.api.ISynchronizerArtefactType.ArtefactState;
+import org.eclipse.dirigible.database.sql.DatabaseArtifactTypes;
+import org.eclipse.dirigible.database.sql.SqlFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The View Drop Processor.
@@ -51,7 +49,7 @@ public class XSKViewDropProcessor extends AbstractXSKProcessor<XSKDataStructureH
   public void execute(Connection connection, XSKDataStructureHDBViewModel viewModel)
       throws SQLException {
     logger.info("Processing Drop View: " + viewModel.getName());
-    String viewNameWithSchema = XSKHDBUtils.escapeArtifactName(connection, viewModel.getName(), viewModel.getSchema());
+    String viewNameWithSchema = XSKHDBUtils.escapeArtifactName(viewModel.getName(), viewModel.getSchema());
 
     //Drop public synonym
     if (managerServices != null) {
@@ -68,7 +66,8 @@ public class XSKViewDropProcessor extends AbstractXSKProcessor<XSKDataStructureH
         applyArtefactState(viewModel.getName(), viewModel.getLocation(), VIEW_ARTEFACT, ArtefactState.SUCCESSFUL_DELETE, message);
       } catch (SQLException ex) {
         String errorMessage = String.format("Drop view [%s] skipped due to an error: %s", viewModel.getName(), ex.getMessage());
-        XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, viewModel.getLocation(), XSKCommonsConstants.HDB_VIEW_PARSER);
+        XSKCommonsUtils.logProcessorErrors(ex.getMessage(), XSKCommonsConstants.PROCESSOR_ERROR, viewModel.getLocation(),
+            XSKCommonsConstants.HDB_VIEW_PARSER);
         applyArtefactState(viewModel.getName(), viewModel.getLocation(), VIEW_ARTEFACT, ArtefactState.FAILED_DELETE, errorMessage);
       }
     } else {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/service/manager/XSKEntityManagerService.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/hdb/ds/service/manager/XSKEntityManagerService.java
@@ -72,7 +72,7 @@ public class XSKEntityManagerService extends AbstractDataStructureManagerService
       throws SQLException {
     if (entitiesModel != null) {
       for (XSKDataStructureHDBTableModel entityModel : entitiesModel.getTableModels()) {
-        String tableName = XSKHDBUtils.escapeArtifactName(connection, entityModel.getName(), entityModel.getSchema());
+        String tableName = XSKHDBUtils.escapeArtifactName(entityModel.getName(), entityModel.getSchema());
         if (!SqlFactory.getNative(connection).exists(connection, tableName)) {
           this.xskTableCreateProcessor.execute(connection, entityModel);
         } else {

--- a/modules/engines/engine-hdb/src/main/java/com/sap/xsk/utils/XSKHDBUtils.java
+++ b/modules/engines/engine-hdb/src/main/java/com/sap/xsk/utils/XSKHDBUtils.java
@@ -32,12 +32,11 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.eclipse.dirigible.api.v3.security.UserFacade;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.database.ds.model.IDataStructureModel;
-import org.eclipse.dirigible.database.sql.SqlFactory;
-import org.eclipse.dirigible.database.sql.dialects.mysql.MySQLSqlDialect;
 
 public class XSKHDBUtils {
 
   private static final String commentRegex = "(/\\*[^*]*\\*+(?:[^/*][^*]*\\*+)*/)|(--.*)";
+  private static final String ESCAPE_SYMBOL = "\"";
 
   private XSKHDBUtils() {
   }
@@ -59,19 +58,18 @@ public class XSKHDBUtils {
    * @param schemaName   name of the schema that will be assembled to the artifact name
    * @return escaped in quotes artifact name
    */
-  public static String escapeArtifactName(Connection connection, String artifactName, String schemaName) {
+  public static String escapeArtifactName(String artifactName, String schemaName) {
     boolean caseSensitive = Boolean.parseBoolean(Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "true"));
-    String escapeSymbol = getEscapeSymbol(connection);
-    if (!artifactName.startsWith(escapeSymbol)) {
+    if (!artifactName.startsWith(ESCAPE_SYMBOL)) {
       if (caseSensitive) {
-        artifactName = escapeSymbol + artifactName + escapeSymbol;
+        artifactName = ESCAPE_SYMBOL + artifactName + ESCAPE_SYMBOL;
       }
     }
 
     if (schemaName != null && !schemaName.trim().isEmpty()) {
-      if (!schemaName.startsWith(escapeSymbol)) {
+      if (!schemaName.startsWith(ESCAPE_SYMBOL)) {
         if (caseSensitive) {
-          schemaName = escapeSymbol + schemaName + escapeSymbol + ".";
+          schemaName = ESCAPE_SYMBOL + schemaName + ESCAPE_SYMBOL + ".";
         } else {
           schemaName = schemaName + ".";
         }
@@ -84,16 +82,10 @@ public class XSKHDBUtils {
   }
 
   /**
-   * See also {@link #escapeArtifactName(Connection, String, String)}.
+   * See also {@link #escapeArtifactName(String, String)}.
    */
-  public static String escapeArtifactName(Connection connection, String artifactName) {
-    return escapeArtifactName(connection, artifactName, null);
-  }
-
-  public static String getEscapeSymbol(Connection connection) {
-    return (SqlFactory.deriveDialect(connection).getClass().equals(MySQLSqlDialect.class))
-        ? "`"
-        : "\"";
+  public static String escapeArtifactName(String artifactName) {
+    return escapeArtifactName(artifactName, null);
   }
 
   public static void populateXSKDataStructureModel(String location, String content, XSKDataStructureModel model, String artifactType,

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/handlers/HDBTableAlterHandlerTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/handlers/HDBTableAlterHandlerTest.java
@@ -12,17 +12,20 @@
 package com.sap.xsk.hdb.ds.test.handlers;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
+import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableColumnModel;
+import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintPrimaryKeyModel;
+import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintsModel;
+import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableModel;
+import com.sap.xsk.hdb.ds.processors.table.utils.XSKTableAlterHandler;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.eclipse.dirigible.api.v3.problems.ProblemsFacade;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.database.ds.model.IDataStructureModel;
@@ -41,225 +44,221 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
-import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableColumnModel;
-import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintPrimaryKeyModel;
-import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintsModel;
-import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableModel;
-import com.sap.xsk.hdb.ds.processors.table.utils.XSKTableAlterHandler;
-
 @RunWith(MockitoJUnitRunner.class)
 public class HDBTableAlterHandlerTest {
 
-	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
-	private Connection mockConnection;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Connection mockConnection;
 
-	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
-	private SqlFactory mockSqlFactory;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private SqlFactory mockSqlFactory;
 
-	@Mock
-	private AlterBranchingBuilder alter;
+  @Mock
+  private AlterBranchingBuilder alter;
 
-	@Mock
-	private AlterTableBuilder alterTableBuilder;
+  @Mock
+  private AlterTableBuilder alterTableBuilder;
 
-	@Mock
-	private DatabaseMetaData databaseMetaData;
+  @Mock
+  private DatabaseMetaData databaseMetaData;
 
-	@Mock
-	private ResultSet resultSet;
+  @Mock
+  private ResultSet resultSet;
 
-	private XSKDataStructureHDBTableConstraintPrimaryKeyModel primaryKey = new XSKDataStructureHDBTableConstraintPrimaryKeyModel();
-	private XSKDataStructureHDBTableConstraintsModel constraintsModel = new XSKDataStructureHDBTableConstraintsModel();
-	private XSKDataStructureHDBTableModel tableModel = new XSKDataStructureHDBTableModel();
+  private XSKDataStructureHDBTableConstraintPrimaryKeyModel primaryKey = new XSKDataStructureHDBTableConstraintPrimaryKeyModel();
+  private XSKDataStructureHDBTableConstraintsModel constraintsModel = new XSKDataStructureHDBTableConstraintsModel();
+  private XSKDataStructureHDBTableModel tableModel = new XSKDataStructureHDBTableModel();
 
-	@Before
-	public void openMocks() {
-		MockitoAnnotations.openMocks(this);
-	}
+  @Before
+  public void openMocks() {
+    MockitoAnnotations.openMocks(this);
+  }
 
-	@Test
-	public void addColumnsSuccessfully() throws Exception {
-		try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
-				MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class)) {
-			configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
-			sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
+  @Test
+  public void addColumnsSuccessfully() throws Exception {
+    try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
+        MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class)) {
+      configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
+      sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
 
-			List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
-			columns.add(new XSKDataStructureHDBTableColumnModel("Id", "NVARCHAR", "32", true, false, null, null, null, true, null));
-			columns.add(new XSKDataStructureHDBTableColumnModel("Name", "NVARCHAR", "32", true, false, null, null, null, false, null));
-			tableModel.setColumns(columns);
-			tableModel.setConstraints(constraintsModel);
-			tableModel.setName("hdb_table::SampleHdbdd");
-			tableModel.setSchema("MYSCHEMA");
+      List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
+      columns.add(new XSKDataStructureHDBTableColumnModel("Id", "NVARCHAR", "32", true, false, null, null, null, true, null));
+      columns.add(new XSKDataStructureHDBTableColumnModel("Name", "NVARCHAR", "32", true, false, null, null, null, false, null));
+      tableModel.setColumns(columns);
+      tableModel.setConstraints(constraintsModel);
+      tableModel.setName("hdb_table::SampleHdbdd");
+      tableModel.setSchema("MYSCHEMA");
 
-			XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
-			XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
+      XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
+      XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
 
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any())).thenReturn(alterTableBuilder);
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any()).add()).thenReturn(alterTableBuilder);
-			when(alterTableBuilder.build()).thenReturn("sql");
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any())).thenReturn(alterTableBuilder);
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any()).add()).thenReturn(alterTableBuilder);
+      when(alterTableBuilder.build()).thenReturn("sql");
 
-			handlerSpy.addColumns(mockConnection);
+      handlerSpy.addColumns(mockConnection);
 //			verifyPrivate(handlerSpy, times(2)).invoke("executeAlterBuilder", mockConnection, alterTableBuilder);
-		}
-	}
+    }
+  }
 
-	@Test(expected = SQLException.class)
-	public void addColumnsFailedWhenPrimaryKey() throws Exception {
-		try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
-				MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class);
-				MockedStatic<ProblemsFacade> problemsFacade = Mockito.mockStatic(ProblemsFacade.class)) {
-			configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
-			sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
+  @Test(expected = SQLException.class)
+  public void addColumnsFailedWhenPrimaryKey() throws Exception {
+    try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
+        MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class);
+        MockedStatic<ProblemsFacade> problemsFacade = Mockito.mockStatic(ProblemsFacade.class)) {
+      configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
+      sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
 
-			List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
-			columns.add(new XSKDataStructureHDBTableColumnModel("Age", "INTEGER", "32", true, true, null, null, null, true, null));
-			tableModel.setColumns(columns);
-			tableModel.setConstraints(constraintsModel);
-			tableModel.setName("hdb_table::SampleHdbdd");
-			tableModel.setSchema("MYSCHEMA");
+      List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
+      columns.add(new XSKDataStructureHDBTableColumnModel("Age", "INTEGER", "32", true, true, null, null, null, true, null));
+      tableModel.setColumns(columns);
+      tableModel.setConstraints(constraintsModel);
+      tableModel.setName("hdb_table::SampleHdbdd");
+      tableModel.setSchema("MYSCHEMA");
 
-			XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
-			XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
+      XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
+      XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
 
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any())).thenReturn(alterTableBuilder);
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any()).add()).thenReturn(alterTableBuilder);
-			problemsFacade.when(() -> ProblemsFacade.save(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenAnswer((Answer<Void>) invocation -> null);
-			handlerSpy.addColumns(mockConnection);
-		}
-	}
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any())).thenReturn(alterTableBuilder);
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any()).add()).thenReturn(alterTableBuilder);
+      problemsFacade.when(() -> ProblemsFacade.save(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+          .thenAnswer((Answer<Void>) invocation -> null);
+      handlerSpy.addColumns(mockConnection);
+    }
+  }
 
-	@Test
-	public void removeColumnsSuccessfully() throws Exception {
+  @Test
+  public void removeColumnsSuccessfully() throws Exception {
 
-		try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
-				MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class)) {
-			configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
-			sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
+    try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
+        MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class)) {
+      configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
+      sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
 
-			List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
-			columns.add(new XSKDataStructureHDBTableColumnModel("Id", "NVARCHAR", "32", true, false, null, null, null, true, null));
-			columns.add(new XSKDataStructureHDBTableColumnModel("Name", "NVARCHAR", "32", true, false, null, null, null, false, null));
-			tableModel.setColumns(columns);
-			tableModel.setConstraints(constraintsModel);
-			tableModel.setName("hdb_table::SampleHdbdd");
-			tableModel.setSchema("MYSCHEMA");
+      List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
+      columns.add(new XSKDataStructureHDBTableColumnModel("Id", "NVARCHAR", "32", true, false, null, null, null, true, null));
+      columns.add(new XSKDataStructureHDBTableColumnModel("Name", "NVARCHAR", "32", true, false, null, null, null, false, null));
+      tableModel.setColumns(columns);
+      tableModel.setConstraints(constraintsModel);
+      tableModel.setName("hdb_table::SampleHdbdd");
+      tableModel.setSchema("MYSCHEMA");
 
-			when(mockConnection.getMetaData()).thenReturn(databaseMetaData);
-			when(databaseMetaData.getColumns(any(), any(), any(), any())).thenReturn(resultSet);
-			when(resultSet.next()).thenReturn(true).thenReturn(false);
-			when(resultSet.getString("COLUMN_NAME")).thenReturn("Test");
-			when(resultSet.getString("TYPE_NAME")).thenReturn("NVARCHAR");
+      when(mockConnection.getMetaData()).thenReturn(databaseMetaData);
+      when(databaseMetaData.getColumns(any(), any(), any(), any())).thenReturn(resultSet);
+      when(resultSet.next()).thenReturn(true).thenReturn(false);
+      when(resultSet.getString("COLUMN_NAME")).thenReturn("Test");
+      when(resultSet.getString("TYPE_NAME")).thenReturn("NVARCHAR");
 
-			XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
-			XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
+      XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
+      XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
 
-			sqlFactory.when(() ->SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any())).thenReturn(alterTableBuilder);
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any()).drop()).thenReturn(alterTableBuilder);
-			when(alterTableBuilder.build()).thenReturn("sql");
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any())).thenReturn(alterTableBuilder);
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any()).drop()).thenReturn(alterTableBuilder);
+      when(alterTableBuilder.build()).thenReturn("sql");
 
-			handlerSpy.removeColumns(mockConnection);
-			// TODO: Refactor -> Mockito doesn't have support for verifyPrivate()
-			// verifyPrivate(handlerSpy, times(1)).invoke("executeAlterBuilder", mockConnection, alterTableBuilder);
-		}
-	}
+      handlerSpy.removeColumns(mockConnection);
+      // TODO: Refactor -> Mockito doesn't have support for verifyPrivate()
+      // verifyPrivate(handlerSpy, times(1)).invoke("executeAlterBuilder", mockConnection, alterTableBuilder);
+    }
+  }
 
-	@Test
-	public void updateColumnsSuccessfully() throws Exception {
-		try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
-				MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class)) {
-			configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
-			sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
+  @Test
+  public void updateColumnsSuccessfully() throws Exception {
+    try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
+        MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class)) {
+      configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
+      sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
 
-			List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
-			columns.add(new XSKDataStructureHDBTableColumnModel("Id", "NVARCHAR", "32", true, false, null, null, null, true, null));
-			columns.add(new XSKDataStructureHDBTableColumnModel("Name", "NVARCHAR", "32", true, false, null, null, null, false, null));
-			tableModel.setColumns(columns);
-			tableModel.setConstraints(constraintsModel);
-			tableModel.setName("hdb_table::SampleHdbdd");
-			tableModel.setSchema("MYSCHEMA");
+      List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
+      columns.add(new XSKDataStructureHDBTableColumnModel("Id", "NVARCHAR", "32", true, false, null, null, null, true, null));
+      columns.add(new XSKDataStructureHDBTableColumnModel("Name", "NVARCHAR", "32", true, false, null, null, null, false, null));
+      tableModel.setColumns(columns);
+      tableModel.setConstraints(constraintsModel);
+      tableModel.setName("hdb_table::SampleHdbdd");
+      tableModel.setSchema("MYSCHEMA");
 
-			when(mockConnection.getMetaData()).thenReturn(databaseMetaData);
-			when(databaseMetaData.getColumns(any(), any(), any(), any())).thenReturn(resultSet);
-			when(resultSet.next()).thenReturn(true).thenReturn(false);
-			when(resultSet.getString("COLUMN_NAME")).thenReturn("Name");
-			when(resultSet.getString("TYPE_NAME")).thenReturn("NVARCHAR");
+      when(mockConnection.getMetaData()).thenReturn(databaseMetaData);
+      when(databaseMetaData.getColumns(any(), any(), any(), any())).thenReturn(resultSet);
+      when(resultSet.next()).thenReturn(true).thenReturn(false);
+      when(resultSet.getString("COLUMN_NAME")).thenReturn("Name");
+      when(resultSet.getString("TYPE_NAME")).thenReturn("NVARCHAR");
 
-			XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
-			XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
+      XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
+      XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
 
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any())).thenReturn(alterTableBuilder);
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any()).alter()).thenReturn(alterTableBuilder);
-			when(alterTableBuilder.build()).thenReturn("sql");
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any())).thenReturn(alterTableBuilder);
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any()).alter()).thenReturn(alterTableBuilder);
+      when(alterTableBuilder.build()).thenReturn("sql");
 
-			handlerSpy.updateColumns(mockConnection);
-			// TODO: Refactor -> Mockito doesn't have support for verifyPrivate()
-			// verifyPrivate(handlerSpy, times(1)).invoke("executeAlterBuilder", mockConnection, alterTableBuilder);
-		}
-	}
+      handlerSpy.updateColumns(mockConnection);
+      // TODO: Refactor -> Mockito doesn't have support for verifyPrivate()
+      // verifyPrivate(handlerSpy, times(1)).invoke("executeAlterBuilder", mockConnection, alterTableBuilder);
+    }
+  }
 
-	@Test
-	public void rebuildIndecesSuccessfully() throws Exception {
-		try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
-				MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class)) {
-			configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
-			sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
-			List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
-			columns.add(new XSKDataStructureHDBTableColumnModel("Id", "NVARCHAR", "32", true, false, null, null, null, true, null));
-			columns.add(new XSKDataStructureHDBTableColumnModel("Name", "NVARCHAR", "32", true, false, null, null, null, false, null));
-			tableModel.setColumns(columns);
-			tableModel.setConstraints(constraintsModel);
-			tableModel.setName("hdb_table::SampleHdbdd");
-			tableModel.setSchema("MYSCHEMA");
+  @Test
+  public void rebuildIndecesSuccessfully() throws Exception {
+    try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
+        MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class)) {
+      configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
+      sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
+      List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
+      columns.add(new XSKDataStructureHDBTableColumnModel("Id", "NVARCHAR", "32", true, false, null, null, null, true, null));
+      columns.add(new XSKDataStructureHDBTableColumnModel("Name", "NVARCHAR", "32", true, false, null, null, null, false, null));
+      tableModel.setColumns(columns);
+      tableModel.setConstraints(constraintsModel);
+      tableModel.setName("hdb_table::SampleHdbdd");
+      tableModel.setSchema("MYSCHEMA");
 
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any())).thenReturn(alterTableBuilder);
-			when(alterTableBuilder.build()).thenReturn("sql");
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter().table(any())).thenReturn(alterTableBuilder);
+      when(alterTableBuilder.build()).thenReturn("sql");
 
-			XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
-			XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
+      XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
+      XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
 
-			handlerSpy.rebuildIndeces(mockConnection);
-			// TODO: Refactor -> Mockito doesn't have support for verifyPrivate()
-			// verifyPrivate(handlerSpy, times(1)).invoke("executeAlterBuilder", mockConnection, alterTableBuilder);
-		}
-	}
+      handlerSpy.rebuildIndeces(mockConnection);
+      // TODO: Refactor -> Mockito doesn't have support for verifyPrivate()
+      // verifyPrivate(handlerSpy, times(1)).invoke("executeAlterBuilder", mockConnection, alterTableBuilder);
+    }
+  }
 
-	@Test(expected = SQLException.class)
-	public void ensurePrimaryKeyIsUnchangedSuccessfully() throws Exception {
-		try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
-				MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class);
-				MockedStatic<ProblemsFacade> problemsFacade = Mockito.mockStatic(ProblemsFacade.class)) {
-			configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
-			sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
+  @Test(expected = SQLException.class)
+  public void ensurePrimaryKeyIsUnchangedSuccessfully() throws Exception {
+    try (MockedStatic<SqlFactory> sqlFactory = Mockito.mockStatic(SqlFactory.class);
+        MockedStatic<Configuration> configuration = Mockito.mockStatic(Configuration.class);
+        MockedStatic<ProblemsFacade> problemsFacade = Mockito.mockStatic(ProblemsFacade.class)) {
+      configuration.when(() -> Configuration.get(IDataStructureModel.DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE, "false")).thenReturn("true");
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection)).thenReturn(mockSqlFactory);
+      sqlFactory.when(() -> SqlFactory.deriveDialect(mockConnection)).thenReturn(new HanaSqlDialect());
 
-			List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
-			columns.add(new XSKDataStructureHDBTableColumnModel("Id", "NVARCHAR", "32", true, true, null, null, null, true, null));
-			columns.add(new XSKDataStructureHDBTableColumnModel("Name", "NVARCHAR", "32", true, false, null, null, null, false, null));
-			tableModel.setColumns(columns);
-			tableModel.setConstraints(constraintsModel);
-			primaryKey.setColumns(new String[] { "Id" });
-			constraintsModel.setPrimaryKey(primaryKey);
-			tableModel.setName("hdb_table::SampleHdbdd");
-			tableModel.setSchema("MYSCHEMA");
+      List<XSKDataStructureHDBTableColumnModel> columns = new ArrayList<>();
+      columns.add(new XSKDataStructureHDBTableColumnModel("Id", "NVARCHAR", "32", true, true, null, null, null, true, null));
+      columns.add(new XSKDataStructureHDBTableColumnModel("Name", "NVARCHAR", "32", true, false, null, null, null, false, null));
+      tableModel.setColumns(columns);
+      tableModel.setConstraints(constraintsModel);
+      primaryKey.setColumns(new String[]{"Id"});
+      constraintsModel.setPrimaryKey(primaryKey);
+      tableModel.setName("hdb_table::SampleHdbdd");
+      tableModel.setSchema("MYSCHEMA");
 
-			sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
-			problemsFacade.when(() -> ProblemsFacade.save(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenAnswer((Answer<Void>) invocation -> null);
-			XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
-			XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
+      sqlFactory.when(() -> SqlFactory.getNative(mockConnection).alter()).thenReturn(alter);
+      problemsFacade.when(() -> ProblemsFacade.save(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+          .thenAnswer((Answer<Void>) invocation -> null);
+      XSKTableAlterHandler tableAlterHandler = new XSKTableAlterHandler(mockConnection, tableModel);
+      XSKTableAlterHandler handlerSpy = spy(tableAlterHandler);
 
-			handlerSpy.ensurePrimaryKeyIsUnchanged(mockConnection);
-		}
-	}
+      handlerSpy.ensurePrimaryKeyIsUnchanged(mockConnection);
+    }
+  }
 
 }

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/handlers/HDBTableAlterHandlerTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/handlers/HDBTableAlterHandlerTest.java
@@ -19,7 +19,7 @@ import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableColumnModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintPrimaryKeyModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableConstraintsModel;
 import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableModel;
-import com.sap.xsk.hdb.ds.processors.table.utils.XSKTableAlterHandler;
+import com.sap.xsk.hdb.ds.processors.table.XSKTableAlterHandler;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;

--- a/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/processors/HDBTableProcessorsTest.java
+++ b/modules/engines/engine-hdb/src/test/java/com/sap/xsk/hdb/ds/test/processors/HDBTableProcessorsTest.java
@@ -16,8 +16,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableModel;
+import com.sap.xsk.hdb.ds.processors.table.XSKTableAlterHandler;
+import com.sap.xsk.hdb.ds.processors.table.XSKTableAlterProcessor;
 import java.sql.Connection;
-
 import org.eclipse.dirigible.core.test.AbstractDirigibleTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,46 +30,42 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.sap.xsk.hdb.ds.model.hdbtable.XSKDataStructureHDBTableModel;
-import com.sap.xsk.hdb.ds.processors.table.XSKTableAlterProcessor;
-import com.sap.xsk.hdb.ds.processors.table.utils.XSKTableAlterHandler;
-
 @RunWith(MockitoJUnitRunner.class)
 public class HDBTableProcessorsTest extends AbstractDirigibleTest {
 
-	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
-	private Connection mockConnection;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Connection mockConnection;
 
-	@Mock
-	private XSKDataStructureHDBTableModel mockModel;
+  @Mock
+  private XSKDataStructureHDBTableModel mockModel;
 
-	@Mock
-	private XSKTableAlterHandler mockHandler;
+  @Mock
+  private XSKTableAlterHandler mockHandler;
 
-	private XSKTableAlterProcessor xskTableAlterProcessor = spy(new XSKTableAlterProcessor());
+  private XSKTableAlterProcessor xskTableAlterProcessor = spy(new XSKTableAlterProcessor());
 
-	@Before
-	public void openMocks() {
-		MockitoAnnotations.openMocks(this);
-	}
+  @Before
+  public void openMocks() {
+    MockitoAnnotations.openMocks(this);
+  }
 
-	@Test
-	public void executeAlterSuccessfully() throws Exception {
-		Mockito.doReturn(mockHandler).when(xskTableAlterProcessor).createTableAlterHandler(mockConnection, mockModel);
+  @Test
+  public void executeAlterSuccessfully() throws Exception {
+    Mockito.doReturn(mockHandler).when(xskTableAlterProcessor).createTableAlterHandler(mockConnection, mockModel);
 
-		doNothing().when(mockHandler).addColumns(mockConnection);
-		doNothing().when(mockHandler).removeColumns(mockConnection);
-		doNothing().when(mockHandler).updateColumns(mockConnection);
-		doNothing().when(mockHandler).rebuildIndeces(mockConnection);
-		doNothing().when(mockHandler).ensurePrimaryKeyIsUnchanged(mockConnection);
+    doNothing().when(mockHandler).addColumns(mockConnection);
+    doNothing().when(mockHandler).removeColumns(mockConnection);
+    doNothing().when(mockHandler).updateColumns(mockConnection);
+    doNothing().when(mockHandler).rebuildIndeces(mockConnection);
+    doNothing().when(mockHandler).ensurePrimaryKeyIsUnchanged(mockConnection);
 
-		xskTableAlterProcessor.execute(mockConnection, mockModel);
+    xskTableAlterProcessor.execute(mockConnection, mockModel);
 
-		verify(mockHandler, times(1)).addColumns(mockConnection);
-		verify(mockHandler, times(1)).removeColumns(mockConnection);
-		verify(mockHandler, times(1)).updateColumns(mockConnection);
-		verify(mockHandler, times(1)).rebuildIndeces(mockConnection);
-		verify(mockHandler, times(1)).ensurePrimaryKeyIsUnchanged(mockConnection);
-	}
+    verify(mockHandler, times(1)).addColumns(mockConnection);
+    verify(mockHandler, times(1)).removeColumns(mockConnection);
+    verify(mockHandler, times(1)).updateColumns(mockConnection);
+    verify(mockHandler, times(1)).rebuildIndeces(mockConnection);
+    verify(mockHandler, times(1)).ensurePrimaryKeyIsUnchanged(mockConnection);
+  }
 
 }


### PR DESCRIPTION
Fix for #1182 

Change log:
1. remove sql create statements split on "CREATE" string in TableCreateProcessor
2. refactor XSKHDBUtils to not require connection for all escape methods
3. remove unnecessary checks for MySQL and PostgreSQL DBs