### PR TITLE
Fix-buildpack-stack

### DIFF
--- a/releng/buildpacks/xsk/Dockerfile
+++ b/releng/buildpacks/xsk/Dockerfile
@@ -1,25 +1,24 @@
 ARG XSK_VERSION=latest
 FROM dirigiblelabs/xsk:$XSK_VERSION as base
 
-ENV CNB_USER_ID=1000
-ENV CNB_GROUP_ID=1000
+ENV CNB_USER_ID=1001
+ENV CNB_GROUP_ID=1001
 ENV CNB_STACK_ID="com.sap.kneo.xsk"
 LABEL io.buildpacks.stack.id="com.sap.kneo.xsk"
 
-RUN groupadd cnb --gid ${CNB_GROUP_ID} && \
-  useradd --uid ${CNB_USER_ID} --gid ${CNB_GROUP_ID} -m -s /bin/bash cnb
+RUN chown -R dirigible:dirigible $CATALINA_HOME
 
 RUN chmod -R 777 /usr/local/tomcat
 
 FROM base as run
 
-RUN chmod -R 777 /usr/local/tomcat
+RUN chown -R dirigible:dirigible $CATALINA_HOME
 
-USER ${CNB_USER_ID}:${CNB_GROUP_ID}
+RUN chmod -R 777 /usr/local/tomcat
 
 FROM base as build
 
-RUN chmod -R 777 /usr/local/tomcat
+RUN chown -R dirigible:dirigible $CATALINA_HOME
 
-USER ${CNB_USER_ID}:${CNB_GROUP_ID}
+RUN chmod -R 777 /usr/local/tomcat
 

--- a/releng/buildpacks/xsk/buildpack/bin/build
+++ b/releng/buildpacks/xsk/buildpack/bin/build
@@ -7,7 +7,7 @@ for n in *; do printf '  - %s\n' "$n"; done
 
 echo "Copy projects ..."
 mkdir -p /usr/local/tomcat/target/dirigible/repository/root/registry/public/
-cp -R */ /usr/local/tomcat/target/dirigible/repository/root/registry/public/
+cp -R * /usr/local/tomcat/target/dirigible/repository/root/registry/public/
 cp -R /usr/local/tomcat/target/ /workspace/target
 rm -rf /usr/local/tomcat/target/
 


### PR DESCRIPTION

#### Changelog

**New**

* Add `RUN chown -R dirigible:dirigible $CATALINA_HOME` to fix the error `chown operation not permitted`

**Changed**

* `CNB_USER_ID` and `CNB_GROUP_ID` is changed to from `1000` to `1001` cause the `dirigiblelabs/xsk` image is change to run without root
* `cp -R */ /usr/local/tomcat/target/dirigible/repository/root/registry/public/` to `cp -R * /usr/local/tomcat/target/dirigible/repository/root/registry/public/` to fix the error `[builder] cp: cannot stat '*/': No such file or directory`

**Removed**

```
RUN groupadd cnb --gid ${CNB_GROUP_ID} && \
  useradd --uid ${CNB_USER_ID} --gid ${CNB_GROUP_ID} -m -s /bin/bash cnb
```
