### PR TITLE
Fix buildpack stack kyma

### DIFF
--- a/releng/buildpacks/xsk-kyma/Dockerfile
+++ b/releng/buildpacks/xsk-kyma/Dockerfile
@@ -1,13 +1,10 @@
 ARG XSK_VERSION=latest
 FROM dirigiblelabs/xsk-kyma:$XSK_VERSION as base
 
-ENV CNB_USER_ID=1000
-ENV CNB_GROUP_ID=1000
+ENV CNB_USER_ID=1001
+ENV CNB_GROUP_ID=1001
 ENV CNB_STACK_ID="com.sap.kneo.xsk"
 LABEL io.buildpacks.stack.id="com.sap.kneo.xsk"
-
-RUN groupadd cnb --gid ${CNB_GROUP_ID} && \
-  useradd --uid ${CNB_USER_ID} --gid ${CNB_GROUP_ID} -m -s /bin/bash cnb
 
 RUN chmod -R 777 /usr/local/tomcat
 
@@ -15,11 +12,6 @@ FROM base as run
 
 RUN chmod -R 777 /usr/local/tomcat
 
-USER ${CNB_USER_ID}:${CNB_GROUP_ID}
-
 FROM base as build
 
 RUN chmod -R 777 /usr/local/tomcat
-
-USER ${CNB_USER_ID}:${CNB_GROUP_ID}
-

--- a/releng/buildpacks/xsk-kyma/buildpack/bin/build
+++ b/releng/buildpacks/xsk-kyma/buildpack/bin/build
@@ -7,7 +7,7 @@ for n in *; do printf '  - %s\n' "$n"; done
 
 echo "Copy projects ..."
 mkdir -p /usr/local/tomcat/target/dirigible/repository/root/registry/public/
-cp -R */ /usr/local/tomcat/target/dirigible/repository/root/registry/public/
+cp -R * /usr/local/tomcat/target/dirigible/repository/root/registry/public/
 cp -R /usr/local/tomcat/target/ /workspace/target
 rm -rf /usr/local/tomcat/target/
 

--- a/releng/buildpacks/xsk/Dockerfile
+++ b/releng/buildpacks/xsk/Dockerfile
@@ -6,19 +6,14 @@ ENV CNB_GROUP_ID=1001
 ENV CNB_STACK_ID="com.sap.kneo.xsk"
 LABEL io.buildpacks.stack.id="com.sap.kneo.xsk"
 
-RUN chown -R dirigible:dirigible $CATALINA_HOME
 
 RUN chmod -R 777 /usr/local/tomcat
 
 FROM base as run
 
-RUN chown -R dirigible:dirigible $CATALINA_HOME
-
 RUN chmod -R 777 /usr/local/tomcat
 
 FROM base as build
-
-RUN chown -R dirigible:dirigible $CATALINA_HOME
 
 RUN chmod -R 777 /usr/local/tomcat
 


### PR DESCRIPTION

#### Changelog

**Changed**

* `CNB_USER_ID` and `CNB_GROUP_ID` is changed to from `1000` to `1001` cause the `dirigiblelabs/xsk` image is change to run without root
* `cp -R */ /usr/local/tomcat/target/dirigible/repository/root/registry/public/` to `cp -R * /usr/local/tomcat/target/dirigible/repository/root/registry/public/` to fix the error `[builder] cp: cannot stat '*/': No such file or directory`

**Removed**

```
RUN groupadd cnb --gid ${CNB_GROUP_ID} && \
  useradd --uid ${CNB_USER_ID} --gid ${CNB_GROUP_ID} -m -s /bin/bash cnb
```
Issue: #1460