### PR TITLE
Fixed issue with invalid cron expression

### DIFF
--- a/modules/engines/engine-xsjob/src/main/java/com/sap/xsk/xsjob/ds/transformer/XSKCronToQuartzCronTransformer.java
+++ b/modules/engines/engine-xsjob/src/main/java/com/sap/xsk/xsjob/ds/transformer/XSKCronToQuartzCronTransformer.java
@@ -15,6 +15,7 @@ import com.sap.xsk.utils.XSKCommonsConstants;
 import com.sap.xsk.utils.XSKCommonsUtils;
 import com.sap.xsk.xsjob.ds.api.XSKCronExpressionException;
 import java.text.ParseException;
+import java.util.List;
 
 public class XSKCronToQuartzCronTransformer {
 
@@ -90,15 +91,12 @@ public class XSKCronToQuartzCronTransformer {
   }
 
   private String checkDayOfWeekAndDayOfMonth(){
-    final String[] xskCronExpressionDayOfWeekArr = {"MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN", "1", "2", "3", "4", "5", "6", "7"};
+    final List<String> xskCronExpressionDayOfWeekArr = List.of("mon", "tue", "wed", "thu", "fri", "sat", "sun", "1", "2", "3", "4", "5", "6", "7");
+    final List<String> dayOfWeekList = List.of(xskCronExpressionArr[XSK_CRON_DAY_OF_WEEK].split(","));
 
-    if (xskCronExpressionArr[XSK_CRON_DAY].equalsIgnoreCase("*")){
-      for (String dayOfWeek : xskCronExpressionDayOfWeekArr ){
-        if (xskCronExpressionArr[XSK_CRON_DAY_OF_WEEK].contains(dayOfWeek)){
-          return "?";
-        }
-      }
-    }
-    return parseRange(xskCronExpressionArr[XSK_CRON_DAY]);
+    boolean isEveryDay = xskCronExpressionArr[XSK_CRON_DAY].equalsIgnoreCase("*");
+    boolean hasDayOfWeek = dayOfWeekList.stream().map(String::toLowerCase).anyMatch(xskCronExpressionDayOfWeekArr::contains);
+
+    return isEveryDay && hasDayOfWeek ? "?" : parseRange(xskCronExpressionArr[XSK_CRON_DAY]);
   }
 }

--- a/modules/engines/engine-xsjob/src/main/java/com/sap/xsk/xsjob/ds/transformer/XSKCronToQuartzCronTransformer.java
+++ b/modules/engines/engine-xsjob/src/main/java/com/sap/xsk/xsjob/ds/transformer/XSKCronToQuartzCronTransformer.java
@@ -39,7 +39,7 @@ public class XSKCronToQuartzCronTransformer {
     try {
       quartzCronExpression.setYear(parseRange(xskCronExpressionArr[XSK_CRON_YEAR]));
       quartzCronExpression.setMonth(parseRange(xskCronExpressionArr[XSK_CRON_MONTH]));
-      quartzCronExpression.setDayOfMonth(parseRange(xskCronExpressionArr[XSK_CRON_DAY]));
+      quartzCronExpression.setDayOfMonth(checkDayOfWeekAndDayOfMonth());
 
       String quartzDayOfWeek = parseRange(xskCronExpressionArr[XSK_CRON_DAY_OF_WEEK]);
       quartzDayOfWeek = parseDayOfWeekElement(quartzDayOfWeek);
@@ -87,5 +87,18 @@ public class XSKCronToQuartzCronTransformer {
     }
 
     throw new XSKCronExpressionException(String.join(" ", xskCronExpressionArr), XSK_CRON_DAY_OF_WEEK);
+  }
+
+  private String checkDayOfWeekAndDayOfMonth(){
+    final String[] xskCronExpressionDayOfWeekArr = {"MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN", "1", "2", "3", "4", "5", "6", "7"};
+
+    if (xskCronExpressionArr[XSK_CRON_DAY].equalsIgnoreCase("*")){
+      for (String dayOfWeek : xskCronExpressionDayOfWeekArr ){
+        if (xskCronExpressionArr[XSK_CRON_DAY_OF_WEEK].contains(dayOfWeek)){
+          return "?";
+        }
+      }
+    }
+    return parseRange(xskCronExpressionArr[XSK_CRON_DAY]);
   }
 }

--- a/modules/engines/engine-xsjob/src/test/java/XSKJobTransformerTest.java
+++ b/modules/engines/engine-xsjob/src/test/java/XSKJobTransformerTest.java
@@ -22,8 +22,6 @@ import org.eclipse.dirigible.api.v3.problems.ProblemsFacade;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -33,16 +31,13 @@ import org.mockito.stubbing.Answer;
 import com.sap.xsk.xsjob.ds.model.XSKJobArtifact;
 import com.sap.xsk.xsjob.ds.model.XSKJobDefinition;
 import com.sap.xsk.xsjob.ds.service.XSKJobCoreService;
-import com.sap.xsk.xsjob.ds.transformer.XSKCronToQuartzCronTransformer;
 import com.sap.xsk.xsjob.ds.transformer.XSKJobToXSKJobDefinitionTransformer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class XSKJobTransformerTest {
 
-	@InjectMocks
-	private XSKJobToXSKJobDefinitionTransformer xskJobToXSKJobDefinitionTransformer = new XSKJobToXSKJobDefinitionTransformer();
-	@Mock
-	private XSKCronToQuartzCronTransformer xskCronToQuartzCronTransformer;
+  private final XSKJobCoreService xskJobCoreService = new XSKJobCoreService();
+  private final XSKJobToXSKJobDefinitionTransformer xskJobToXSKJobDefinitionTransformer = new XSKJobToXSKJobDefinitionTransformer();
 
 	@Before
 	public void openMocks() {
@@ -51,10 +46,10 @@ public class XSKJobTransformerTest {
 
 	@Test
 	public void executeTransformSuccessfully() throws Exception {
-		XSKJobCoreService xskJobCoreService = new XSKJobCoreService();
-		String xsjobSample = IOUtils.toString(XSKJobTransformerTest.class.getResourceAsStream("/TestXSKJobTransformSuccess.xsjob"), StandardCharsets.UTF_8);
+    String EXPECTED_CRON_EXPRESSION_EVERY_FIVE_SECONDS = "*/5 * * * * ? *";
+    String xsjobSample = IOUtils.toString(XSKJobTransformerTest.class.getResourceAsStream("/TestXSKJobTransformSuccess.xsjob"), StandardCharsets.UTF_8);
 		XSKJobArtifact xskJobArtifact = xskJobCoreService.parseJob(xsjobSample);
-		String cronExpression = xskCronToQuartzCronTransformer.transform(xskJobArtifact.getSchedules().get(0).getXscron());
+
 		Map<String, String> parametersAsMap = xskJobArtifact.getSchedules().get(0).getParameter();
 		ArrayList<XSKJobDefinition> jobDefinitions = xskJobToXSKJobDefinitionTransformer.transform(xskJobArtifact);
 
@@ -62,7 +57,7 @@ public class XSKJobTransformerTest {
 		assertEquals("XSJOB/bugXsjob.xsjs", jobDefinitions.get(0).getModule());
 		assertEquals("logFunc", jobDefinitions.get(0).getFunction());
 		assertEquals("My Job configuration My Schedule configuration for execution every second", jobDefinitions.get(0).getDescription());
-		assertEquals(cronExpression, jobDefinitions.get(0).getCronExpression());
+    assertEquals(EXPECTED_CRON_EXPRESSION_EVERY_FIVE_SECONDS, jobDefinitions.get(0).getCronExpression());
 		assertEquals(parametersAsMap, jobDefinitions.get(0).getParametersAsMap());
 		assertEquals(parametersAsMap.size(), 1);
 		assertEquals(jobDefinitions.size(), 1);
@@ -72,7 +67,6 @@ public class XSKJobTransformerTest {
 	public void executeTransformFailed() throws Exception {
 		try (MockedStatic<ProblemsFacade> problemsFacade = Mockito.mockStatic(ProblemsFacade.class)) {
 			problemsFacade.when(() -> ProblemsFacade.save(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenAnswer((Answer<Void>) invocation -> null);
-			XSKJobCoreService xskJobCoreService = new XSKJobCoreService();
 			String xsjobSample = IOUtils.toString(XSKJobTransformerTest.class.getResourceAsStream("/TestXSKJobTransformFailure.xsjob"), StandardCharsets.UTF_8);
 			XSKJobArtifact xskJobArtifact = xskJobCoreService.parseJob(xsjobSample);
 			xskJobToXSKJobDefinitionTransformer.transform(xskJobArtifact);
@@ -81,11 +75,18 @@ public class XSKJobTransformerTest {
 
 	@Test
 	public void executeTransformWithEmptySchedule() throws Exception {
-		XSKJobCoreService xskJobCoreService = new XSKJobCoreService();
 		String xsjobSample = IOUtils.toString(XSKJobTransformerTest.class.getResourceAsStream("/TestXSKJobTransformWithEmptySchedule.xsjob"), StandardCharsets.UTF_8);
 		XSKJobArtifact xskJobArtifact = xskJobCoreService.parseJob(xsjobSample);
 		ArrayList<XSKJobDefinition> jobDefinitions = xskJobToXSKJobDefinitionTransformer.transform(xskJobArtifact);
 		assertEquals(jobDefinitions.size(), 0);
 	}
 
+  @Test
+  public void executeTransformCronExpression() throws Exception {
+    String EXPECTED_CRON_EXPRESSION_EVERY_WEEK_DAY = "0 30 22 ? * MON,TUE,WED,THU,FRI *";
+    String xsjobSample = IOUtils.toString(XSKJobTransformerTest.class.getResourceAsStream("/TestXSKJobTransformerCronExpression.xsjob"), StandardCharsets.UTF_8);
+    XSKJobArtifact xskJobArtifact = xskJobCoreService.parseJob(xsjobSample);
+    ArrayList<XSKJobDefinition> jobDefinitions = xskJobToXSKJobDefinitionTransformer.transform(xskJobArtifact);
+    assertEquals(jobDefinitions.get(0).getCronExpression(), EXPECTED_CRON_EXPRESSION_EVERY_WEEK_DAY);
+  }
 }

--- a/modules/engines/engine-xsjob/src/test/java/XSKJobTransformerTest.java
+++ b/modules/engines/engine-xsjob/src/test/java/XSKJobTransformerTest.java
@@ -19,12 +19,10 @@ import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.dirigible.api.v3.problems.ProblemsFacade;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
@@ -39,17 +37,11 @@ public class XSKJobTransformerTest {
   private final XSKJobCoreService xskJobCoreService = new XSKJobCoreService();
   private final XSKJobToXSKJobDefinitionTransformer xskJobToXSKJobDefinitionTransformer = new XSKJobToXSKJobDefinitionTransformer();
 
-	@Before
-	public void openMocks() {
-		MockitoAnnotations.openMocks(this);
-	}
-
 	@Test
 	public void executeTransformSuccessfully() throws Exception {
-    String EXPECTED_CRON_EXPRESSION_EVERY_FIVE_SECONDS = "*/5 * * * * ? *";
+    String expectedCronExpressionEveryFiveSeconds = "*/5 * * * * ? *";
     String xsjobSample = IOUtils.toString(XSKJobTransformerTest.class.getResourceAsStream("/TestXSKJobTransformSuccess.xsjob"), StandardCharsets.UTF_8);
 		XSKJobArtifact xskJobArtifact = xskJobCoreService.parseJob(xsjobSample);
-
 		Map<String, String> parametersAsMap = xskJobArtifact.getSchedules().get(0).getParameter();
 		ArrayList<XSKJobDefinition> jobDefinitions = xskJobToXSKJobDefinitionTransformer.transform(xskJobArtifact);
 
@@ -57,7 +49,7 @@ public class XSKJobTransformerTest {
 		assertEquals("XSJOB/bugXsjob.xsjs", jobDefinitions.get(0).getModule());
 		assertEquals("logFunc", jobDefinitions.get(0).getFunction());
 		assertEquals("My Job configuration My Schedule configuration for execution every second", jobDefinitions.get(0).getDescription());
-    assertEquals(EXPECTED_CRON_EXPRESSION_EVERY_FIVE_SECONDS, jobDefinitions.get(0).getCronExpression());
+    assertEquals(expectedCronExpressionEveryFiveSeconds, jobDefinitions.get(0).getCronExpression());
 		assertEquals(parametersAsMap, jobDefinitions.get(0).getParametersAsMap());
 		assertEquals(parametersAsMap.size(), 1);
 		assertEquals(jobDefinitions.size(), 1);
@@ -82,11 +74,12 @@ public class XSKJobTransformerTest {
 	}
 
   @Test
-  public void executeTransformCronExpression() throws Exception {
-    String EXPECTED_CRON_EXPRESSION_EVERY_WEEK_DAY = "0 30 22 ? * MON,TUE,WED,THU,FRI *";
+  public void testTransformEachDayOfWeekAndMonth() throws Exception {
+    String expectedCronExpressionEveryWeekDay = "0 30 22 ? * MON,TUE,WED,THU,FRI *";
     String xsjobSample = IOUtils.toString(XSKJobTransformerTest.class.getResourceAsStream("/TestXSKJobTransformerCronExpression.xsjob"), StandardCharsets.UTF_8);
     XSKJobArtifact xskJobArtifact = xskJobCoreService.parseJob(xsjobSample);
     ArrayList<XSKJobDefinition> jobDefinitions = xskJobToXSKJobDefinitionTransformer.transform(xskJobArtifact);
-    assertEquals(jobDefinitions.get(0).getCronExpression(), EXPECTED_CRON_EXPRESSION_EVERY_WEEK_DAY);
+    assertEquals(jobDefinitions.size(), 1);
+    assertEquals(jobDefinitions.get(0).getCronExpression(), expectedCronExpressionEveryWeekDay);
   }
 }

--- a/modules/engines/engine-xsjob/src/test/resources/TestXSKJobTransformerCronExpression.xsjob
+++ b/modules/engines/engine-xsjob/src/test/resources/TestXSKJobTransformerCronExpression.xsjob
@@ -3,7 +3,7 @@
     "action": "xsjob_cron_demo:handler.xsjslib::consolePrintSuccess",
     "schedules": [
         {
-            "description": "Execute at 10:30:00am, on every Monday, Tuesday, Wednesday, Thursday and Friday, every month",
+            "description": "Execute at 10:30:00pm, on every Monday, Tuesday, Wednesday, Thursday and Friday, every month",
             "xscron": "* * * MON,TUE,WED,THU,FRI 22 30 0",
             "parameter": {}
         }

--- a/modules/engines/engine-xsjob/src/test/resources/TestXSKJobTransformerCronExpression.xsjob
+++ b/modules/engines/engine-xsjob/src/test/resources/TestXSKJobTransformerCronExpression.xsjob
@@ -1,0 +1,11 @@
+{
+    "description": "My Job configuration",
+    "action": "xsjob_cron_demo:handler.xsjslib::consolePrintSuccess",
+    "schedules": [
+        {
+            "description": "Execute at 10:30:00am, on every Monday, Tuesday, Wednesday, Thursday and Friday, every month",
+            "xscron": "* * * MON,TUE,WED,THU,FRI 22 30 0",
+            "parameter": {}
+        }
+    ]
+}


### PR DESCRIPTION
Closes sap/fundamental#
[Jobs] Unsupported cron expression #1382
**Changed**
Specifying both a day-of-week and a day-of-month parameter is not supported by the QuartzCronExpression. Added a check for them in order to change the day of month parameter to a "?".
