### PR TITLE
Add properties for destinations in XSJS API

### DIFF
--- a/modules/api/api-xsjs/pom.xml
+++ b/modules/api/api-xsjs/pom.xml
@@ -41,6 +41,24 @@
       <artifactId>scp-cf</artifactId>
       <version>${scp-cf.version}</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/CloudPlatformDestinationFacade.java
+++ b/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/CloudPlatformDestinationFacade.java
@@ -46,10 +46,9 @@ public class CloudPlatformDestinationFacade implements IScriptingFacade {
           }
         });
 
-    URI uri = URI.create((String) DestinationAccessor.getDestination(destinationName).get("URL").get());
+    URI uri = URI.create((String) fetchedDestination.get("URL").get());
 
-    Destination destination = new Destination(uri.getHost(), uri.getPort(), uri.getPath());
-    destination.setProperties(destinationProperties);
+    Destination destination = new Destination(uri.getHost(), uri.getPort(), uri.getPath(), destinationProperties);
 
     return destination;
   }

--- a/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/CloudPlatformDestinationFacade.java
+++ b/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/CloudPlatformDestinationFacade.java
@@ -40,7 +40,7 @@ public class CloudPlatformDestinationFacade implements IScriptingFacade {
     com.sap.cloud.sdk.cloudplatform.connectivity.Destination fetchedDestination = DestinationAccessor.getDestination(destinationName);
     fetchedDestination.getPropertyNames()
         .forEach(propName -> {
-          Option property = fetchedDestination.get(propName);
+          Option<Object> property = fetchedDestination.get(propName);
           if (!property.isEmpty()) {
             destinationProperties.put(propName, property.get());
           }
@@ -48,9 +48,7 @@ public class CloudPlatformDestinationFacade implements IScriptingFacade {
 
     URI uri = URI.create((String) fetchedDestination.get("URL").get());
 
-    Destination destination = new Destination(uri.getHost(), uri.getPort(), uri.getPath(), destinationProperties);
-
-    return destination;
+    return new Destination(uri.getHost(), uri.getPort(), uri.getPath(), destinationProperties);
   }
 
   public static String executeRequest(String requestObject, String destinationName, String options)

--- a/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/CloudPlatformDestinationFacade.java
+++ b/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/CloudPlatformDestinationFacade.java
@@ -12,9 +12,10 @@
 package com.sap.xsk.api.destination;
 
 import com.sap.cloud.sdk.cloudplatform.CloudPlatformAccessor;
-import com.sap.cloud.sdk.cloudplatform.connectivity.Destination;
 import com.sap.cloud.sdk.cloudplatform.connectivity.DestinationAccessor;
 import com.sap.cloud.sdk.cloudplatform.connectivity.HttpClientAccessor;
+import com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestination;
+import io.vavr.control.Option;
 import org.apache.http.HttpResponse;
 import org.apache.http.MethodNotSupportedException;
 import org.apache.http.client.HttpClient;
@@ -28,21 +29,40 @@ import org.eclipse.dirigible.api.v3.http.HttpClientFacade;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Properties;
 
 public class CloudPlatformDestinationFacade implements IScriptingFacade {
-  public static Destination getDestination(String name) {
+
+  public static Destination getDestination(String destinationName) {
     setKymaCloudPlatformFacade();
 
-    return DestinationAccessor.getDestination(name);
+    Properties destinationProperties = new Properties();
+    com.sap.cloud.sdk.cloudplatform.connectivity.Destination fetchedDestination = DestinationAccessor.getDestination(destinationName);
+    fetchedDestination.getPropertyNames()
+        .forEach(propName -> {
+          Option property = fetchedDestination.get(propName);
+          if (!property.isEmpty()) {
+            destinationProperties.put(propName, property.get());
+          }
+        });
+
+    URI uri = URI.create((String) DestinationAccessor.getDestination(destinationName).get("URL").get());
+
+    Destination destination = new Destination(uri.getHost(), uri.getPort(), uri.getPath());
+    destination.setProperties(destinationProperties);
+
+    return destination;
   }
 
-  public static String executeRequest(String requestObject, Destination destination, String options) throws IOException, MethodNotSupportedException {
+  public static String executeRequest(String requestObject, String destinationName, String options)
+      throws IOException, MethodNotSupportedException {
     setKymaCloudPlatformFacade();
 
     DestinationRequest destinationRequest = GsonHelper.GSON.fromJson(requestObject, DestinationRequest.class);
     HttpClientRequestOptions parsedOptions = HttpClientFacade.parseOptions(options);
-    HttpClient client = HttpClientAccessor.getHttpClient(destination.asHttp());
-    String uri = URI.create(destination.asHttp().getUri() + destinationRequest.getQueryPath()).toString();
+    HttpDestination httpDestination = DestinationAccessor.getDestination(destinationName).asHttp();
+    HttpClient client = HttpClientAccessor.getHttpClient(httpDestination);
+    String uri = URI.create(httpDestination.getUri() + destinationRequest.getQueryPath()).toString();
     HttpRequestBase request = getRequest(uri, destinationRequest, parsedOptions);
     setRequestHeaders(destinationRequest, request);
 
@@ -59,14 +79,15 @@ public class CloudPlatformDestinationFacade implements IScriptingFacade {
   }
 
   private static void setKymaCloudPlatformFacade() {
-    if(CloudPlatformAccessor.getCloudPlatformFacade() instanceof CloudPlatformKymaFacade) {
+    if (CloudPlatformAccessor.getCloudPlatformFacade() instanceof CloudPlatformKymaFacade) {
       return;
     }
 
     CloudPlatformAccessor.setCloudPlatformFacade(new CloudPlatformKymaFacade());
   }
 
-  private static HttpRequestBase getRequest(String uri, DestinationRequest destinationRequest, HttpClientRequestOptions options) throws MethodNotSupportedException, IOException {
+  private static HttpRequestBase getRequest(String uri, DestinationRequest destinationRequest, HttpClientRequestOptions options)
+      throws MethodNotSupportedException, IOException {
     switch (destinationRequest.getMethod()) {
       case 0:
         return new HttpOptions();

--- a/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/Destination.java
+++ b/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/Destination.java
@@ -11,7 +11,6 @@
  */
 package com.sap.xsk.api.destination;
 
-import com.google.gson.JsonObject;
 import org.eclipse.dirigible.commons.api.helpers.GsonHelper;
 import java.util.Properties;
 
@@ -22,10 +21,11 @@ public class Destination {
   private String pathPrefix;
   private Properties properties = new Properties();
 
-  Destination(String host, int port, String pathPrefix) {
+  Destination(String host, int port, String pathPrefix, Properties properties) {
     this.host = host;
     this.port = port;
     this.pathPrefix = pathPrefix;
+    this.properties = properties;
   }
 
   public String getHost() {
@@ -40,10 +40,6 @@ public class Destination {
 
   public Properties getProperties() {
     return properties;
-  }
-
-  public void setProperties(Properties properties) {
-    this.properties = properties;
   }
 
   public String getPropertiesAsJSON() {

--- a/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/Destination.java
+++ b/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/Destination.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and XSK contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and XSK contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.xsk.api.destination;
+
+import com.google.gson.JsonObject;
+import org.eclipse.dirigible.commons.api.helpers.GsonHelper;
+import java.util.Properties;
+
+public class Destination {
+
+  private String host;
+  private int port;
+  private String pathPrefix;
+  private Properties properties = new Properties();
+
+  Destination(String host, int port, String pathPrefix) {
+    this.host = host;
+    this.port = port;
+    this.pathPrefix = pathPrefix;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getPathPrefix() { return pathPrefix; }
+
+  public Properties getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Properties properties) {
+    this.properties = properties;
+  }
+
+  public String getPropertiesAsJSON() {
+    return GsonHelper.GSON.toJson(getProperties());
+  }
+}

--- a/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/Destination.java
+++ b/modules/api/api-xsjs/src/main/java/com/sap/xsk/api/destination/Destination.java
@@ -21,7 +21,7 @@ public class Destination {
   private String pathPrefix;
   private Properties properties = new Properties();
 
-  Destination(String host, int port, String pathPrefix, Properties properties) {
+  public Destination(String host, int port, String pathPrefix, Properties properties) {
     this.host = host;
     this.port = port;
     this.pathPrefix = pathPrefix;

--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/http/http.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/http/http.js
@@ -69,15 +69,15 @@ var SET_COOKIE_HEADER = "Set-Cookie";
 var CONTENT_LENGTH_HEADER = "Content-Length";
 
 exports.readDestination = function (destinationPackage, destinationName) {
-  var readDestination = com.sap.xsk.api.destination.CloudPlatformDestinationFacade.getDestination(destinationName);
-  var destination = new exports.Destination();
+  let readDestination = com.sap.xsk.api.destination.CloudPlatformDestinationFacade.getDestination(destinationName);
+  let destination = new exports.Destination();
 
   destination.host = readDestination.getHost();
   destination.port = readDestination.getPort();
   destination.pathPrefix = readDestination.getPathPrefix();
   destination.name = destinationName;
 
-  var properties = JSON.parse(readDestination.getPropertiesAsJSON());
+  let properties = JSON.parse(readDestination.getPropertiesAsJSON());
 
   return Object.assign(destination, properties);
 };

--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/http/http.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/http/http.js
@@ -69,9 +69,17 @@ var SET_COOKIE_HEADER = "Set-Cookie";
 var CONTENT_LENGTH_HEADER = "Content-Length";
 
 exports.readDestination = function (destinationPackage, destinationName) {
-  var destination = com.sap.xsk.api.destination.CloudPlatformDestinationFacade.getDestination(destinationName);
+  var readDestination = com.sap.xsk.api.destination.CloudPlatformDestinationFacade.getDestination(destinationName);
+  var destination = new exports.Destination();
 
-  return destination;
+  destination.host = readDestination.getHost();
+  destination.port = readDestination.getPort();
+  destination.pathPrefix = readDestination.getPathPrefix();
+  destination.name = destinationName;
+
+  var properties = JSON.parse(readDestination.getPropertiesAsJSON());
+
+  return Object.assign(destination, properties);
 };
 
 exports.Client = function () {
@@ -125,14 +133,14 @@ exports.Client = function () {
     let options = {};
 
     if (requestObj.body) {
-        if (typeof requestObj.body === 'string' || requestObj.bodyy instanceof String) {
+        if (typeof requestObj.body === 'string' || requestObj.body instanceof String) {
           options.text = requestObj.body;
         } else {
           options.text = JSON.stringify(requestObj.body);
         }
     }
 
-    clientResponse = com.sap.xsk.api.destination.CloudPlatformDestinationFacade.executeRequest(JSON.stringify(requestObj), destination, JSON.stringify(options));
+    clientResponse = com.sap.xsk.api.destination.CloudPlatformDestinationFacade.executeRequest(JSON.stringify(requestObj), destination.name, JSON.stringify(options));
   }
 
   function sendRequestObjToUrl(requestObj, url, proxy) {

--- a/modules/api/api-xsjs/src/test/java/com/sap/xsk/api/test/CloudPlatformDestinationFacadeTest.java
+++ b/modules/api/api-xsjs/src/test/java/com/sap/xsk/api/test/CloudPlatformDestinationFacadeTest.java
@@ -74,9 +74,14 @@ public class CloudPlatformDestinationFacadeTest {
 
   @After
   public void close() {
+
+    if (!isKymaFacadeSet) {
+      cloudPlatformAccessor.verify(() -> CloudPlatformAccessor.setCloudPlatformFacade(any()));
+    }
     destinationAccessor.close();
     httpClientAccessor.close();
     cloudPlatformAccessor.close();
+
   }
 
 
@@ -127,11 +132,6 @@ public class CloudPlatformDestinationFacadeTest {
     assertEquals("test-destination.com", dest.getHost());
     assertEquals(8080, dest.getPort());
     assertEquals("/destination", dest.getPathPrefix());
-
-    if (!isKymaFacadeSet) {
-      cloudPlatformAccessor.verify(() -> CloudPlatformAccessor.setCloudPlatformFacade(any()));
-    }
-
   }
 
   @Test
@@ -141,10 +141,6 @@ public class CloudPlatformDestinationFacadeTest {
 
     String response = CloudPlatformDestinationFacade.executeRequest(request, destinationName, options);
     assertEquals("{\"headers\":[],\"statusCode\":200,\"text\":\"success\"}", response);
-
-    if (!isKymaFacadeSet) {
-      cloudPlatformAccessor.verify(() -> CloudPlatformAccessor.setCloudPlatformFacade(any()));
-    }
   }
 
 }

--- a/modules/api/api-xsjs/src/test/java/com/sap/xsk/api/test/CloudPlatformDestinationFacadeTest.java
+++ b/modules/api/api-xsjs/src/test/java/com/sap/xsk/api/test/CloudPlatformDestinationFacadeTest.java
@@ -47,13 +47,13 @@ import static org.mockito.Mockito.when;
 @RunWith(Parameterized.class)
 public class CloudPlatformDestinationFacadeTest {
 
-  HttpClient httpClient;
-  String destinationName = "test-destination";
-  String DESTINATION_URI = "http://test-destination.com:8080/destination";
-  MockedStatic<DestinationAccessor> destinationAccessor;
-  MockedStatic<HttpClientAccessor> httpClientAccessor;
-  MockedStatic<CloudPlatformAccessor> cloudPlatformAccessor;
-  boolean isKymaFacadeSet = false;
+  private HttpClient httpClient;
+  private String destinationName = "test-destination";
+  private String DESTINATION_URI = "http://test-destination.com:8080/destination";
+  private MockedStatic<DestinationAccessor> destinationAccessor;
+  private MockedStatic<HttpClientAccessor> httpClientAccessor;
+  private MockedStatic<CloudPlatformAccessor> cloudPlatformAccessor;
+  private boolean isKymaFacadeSet = false;
 
   @Parameters
   public static Collection<Object[]> data() {

--- a/modules/api/api-xsjs/src/test/java/com/sap/xsk/api/test/CloudPlatformDestinationFacadeTest.java
+++ b/modules/api/api-xsjs/src/test/java/com/sap/xsk/api/test/CloudPlatformDestinationFacadeTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and XSK contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and XSK contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.xsk.api.test;
+
+import com.sap.cloud.sdk.cloudplatform.connectivity.AuthenticationType;
+import com.sap.cloud.sdk.cloudplatform.connectivity.DestinationAccessor;
+import com.sap.cloud.sdk.cloudplatform.connectivity.HttpClientAccessor;
+import com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestination;
+import com.sap.xsk.api.destination.CloudPlatformDestinationFacade;
+import io.vavr.control.Option;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import static org.mockito.ArgumentMatchers.any;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import com.sap.xsk.api.destination.Destination;
+import java.net.URI;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class CloudPlatformDestinationFacadeTest {
+
+  HttpClient httpClient;
+  String destinationName = "test-destination";
+  String DESTINATION_URI = "http://test-destination.com:8080/destination";
+  MockedStatic<DestinationAccessor> destinationAccessor;
+  MockedStatic<HttpClientAccessor> httpClientAccessor;
+
+  @Before
+  public void setup() throws IOException {
+    mockRequest();
+    mockAccessors();
+  }
+
+  @After
+  public void close() {
+    destinationAccessor.close();
+    httpClientAccessor.close();
+  }
+
+
+  public void mockAccessors() {
+    destinationAccessor = Mockito.mockStatic(DestinationAccessor.class);
+    httpClientAccessor = Mockito.mockStatic(HttpClientAccessor.class);
+
+    com.sap.cloud.sdk.cloudplatform.connectivity.Destination mockedDestination = Mockito.mock(com.sap.cloud.sdk.cloudplatform.connectivity.Destination.class);
+    when(mockedDestination.get("URL")).thenReturn(Option.of(DESTINATION_URI));
+
+    HttpDestination mockedHttpDestination = Mockito.mock(HttpDestination.class);
+    when(mockedHttpDestination.getAuthenticationType()).thenReturn(AuthenticationType.NO_AUTHENTICATION);
+    when(mockedHttpDestination.getUri()).thenReturn(URI.create(DESTINATION_URI));
+
+    when(mockedDestination.asHttp()).thenReturn(mockedHttpDestination);
+
+    destinationAccessor.when(() -> DestinationAccessor.getDestination(destinationName))
+        .thenReturn(mockedDestination);
+
+    httpClientAccessor.when(() -> HttpClientAccessor.getHttpClient(any()))
+        .thenReturn(httpClient);
+  }
+
+  public void mockRequest() throws IOException {
+    httpClient = Mockito.mock(HttpClient.class);
+    HttpResponse httpResponse = Mockito.mock(HttpResponse.class);
+    StatusLine statusLine = Mockito.mock(StatusLine.class);
+
+    when(statusLine.getStatusCode()).thenReturn(200);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(httpResponse.getAllHeaders()).thenReturn(new Header[0]);
+    when(httpClient.execute(any())).thenReturn(httpResponse);
+
+    HttpEntity mockedEntity = Mockito.mock(HttpEntity.class);
+    when(mockedEntity.getContent()).thenReturn(new ByteArrayInputStream("success".getBytes()));
+
+    when(httpResponse.getEntity()).thenReturn(mockedEntity);
+  }
+
+  @Test
+  public void getDestinationTest() throws Exception {
+    Destination dest = CloudPlatformDestinationFacade.getDestination(destinationName);
+    assertEquals("test-destination.com", dest.getHost());
+    assertEquals(8080, dest.getPort());
+    assertEquals("/destination", dest.getPathPrefix());
+
+  }
+
+  @Test
+  public void executeDestinationRequestTest() throws Exception {
+    String request = "{\"method\": 1, \"queryPath\": \"test-destination.com\", \"headers\": []}";
+    String options = "{}";
+
+    String response = CloudPlatformDestinationFacade.executeRequest(request, destinationName, options);
+    assertEquals("{\"headers\":[],\"statusCode\":200,\"text\":\"success\"}", response);
+  }
+
+}

--- a/modules/engines/engine-mail-destination/pom.xml
+++ b/modules/engines/engine-mail-destination/pom.xml
@@ -32,6 +32,30 @@
       <artifactId>scp-cf</artifactId>
       <version>${scp-cf.version}</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>RELEASE</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/modules/engines/engine-mail-destination/pom.xml
+++ b/modules/engines/engine-mail-destination/pom.xml
@@ -50,12 +50,6 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>RELEASE</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <properties>

--- a/modules/engines/engine-mail-destination/src/main/java/com/sap/xsk/mail/DestMailConfigProvider.java
+++ b/modules/engines/engine-mail-destination/src/main/java/com/sap/xsk/mail/DestMailConfigProvider.java
@@ -14,7 +14,6 @@ package com.sap.xsk.mail;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.xsk.api.destination.CloudPlatformDestinationFacade;
 import org.eclipse.dirigible.api.v3.mail.api.IMailConfigurationProvider;
-import com.sap.xsk.api.destination.Destination;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/modules/engines/engine-mail-destination/src/main/java/com/sap/xsk/mail/DestMailConfigProvider.java
+++ b/modules/engines/engine-mail-destination/src/main/java/com/sap/xsk/mail/DestMailConfigProvider.java
@@ -14,7 +14,7 @@ package com.sap.xsk.mail;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.xsk.api.destination.CloudPlatformDestinationFacade;
 import org.eclipse.dirigible.api.v3.mail.api.IMailConfigurationProvider;
-import com.sap.cloud.sdk.cloudplatform.connectivity.Destination;
+import com.sap.xsk.api.destination.Destination;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,10 +49,10 @@ public class DestMailConfigProvider implements IMailConfigurationProvider {
     Properties properties = new Properties();
     try {
       String destinationName = Configuration.get(DESTINATION_NAME);
-      Destination destination = CloudPlatformDestinationFacade.getDestination(destinationName);
+      Properties destinationProperties = CloudPlatformDestinationFacade.getDestination(destinationName).getProperties();
       for (String key : MAIL_PROPERTIES) {
-        if(!destination.get(key).isEmpty()) {
-          properties.put(key, destination.get(key).get());
+        if(destinationProperties.containsKey(key)) {
+          properties.put(key, destinationProperties.get(key));
         }
       }
     } catch (DestinationAccessException e) {

--- a/modules/engines/engine-mail-destination/src/test/java/com/sap/xsk/mail/test/DestMailConfigProviderTest.java
+++ b/modules/engines/engine-mail-destination/src/test/java/com/sap/xsk/mail/test/DestMailConfigProviderTest.java
@@ -45,7 +45,7 @@ public class DestMailConfigProviderTest {
 
   public void mock() {
     Properties props = new Properties();
-    props.setProperty("mail.user", "dirigible@eclipse.com");
+    props.setProperty("mail.user", "user@xsk.io");
 
     configurationMock = Mockito.mockStatic(Configuration.class);
     configurationMock.when(() -> Configuration.get(MAIL_SERVER_DESTINATION_NAME))

--- a/modules/engines/engine-mail-destination/src/test/java/com/sap/xsk/mail/test/DestMailConfigProviderTest.java
+++ b/modules/engines/engine-mail-destination/src/test/java/com/sap/xsk/mail/test/DestMailConfigProviderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and XSK contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and XSK contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.xsk.mail.test;
+
+import com.sap.xsk.api.destination.CloudPlatformDestinationFacade;
+import com.sap.xsk.mail.DestMailConfigProvider;
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class DestMailConfigProviderTest {
+
+  private static final String MAIL_SERVER_DESTINATION_NAME = "MAIL_SERVER_DESTINATION_NAME";
+  private static final String DESTINATION_NAME = "test-destination";
+
+  MockedStatic<CloudPlatformDestinationFacade> cloudPlatformDestinationFacadeMock;
+  MockedStatic<Configuration>configurationMock;
+
+  @Before
+  public void setup() {
+    mock();
+  }
+
+  @After
+  public void close() {
+    configurationMock.close();
+    cloudPlatformDestinationFacadeMock.close();
+  }
+
+  public void mock() {
+    Properties props = new Properties();
+    props.setProperty("mail.user", "dirigible@eclipse.com");
+
+    configurationMock = Mockito.mockStatic(Configuration.class);
+    configurationMock.when(() -> Configuration.get(MAIL_SERVER_DESTINATION_NAME))
+        .thenReturn(DESTINATION_NAME);
+    com.sap.xsk.api.destination.Destination mockedDestination = Mockito.mock(com.sap.xsk.api.destination.Destination.class);
+    when(mockedDestination.getProperties()).thenReturn(props);
+
+    cloudPlatformDestinationFacadeMock = Mockito.mockStatic(CloudPlatformDestinationFacade.class);
+    cloudPlatformDestinationFacadeMock.when(() -> CloudPlatformDestinationFacade.getDestination(DESTINATION_NAME))
+        .thenReturn(mockedDestination);
+  }
+
+  @Test
+  public void getPropertiesTest() {
+    DestMailConfigProvider provider = new DestMailConfigProvider();
+    Properties properties = provider.getProperties();
+    assertEquals(1, properties.size());
+  }
+
+}

--- a/modules/engines/engine-mail-destination/src/test/java/com/sap/xsk/mail/test/DestMailConfigProviderTest.java
+++ b/modules/engines/engine-mail-destination/src/test/java/com/sap/xsk/mail/test/DestMailConfigProviderTest.java
@@ -29,8 +29,8 @@ public class DestMailConfigProviderTest {
   private static final String MAIL_SERVER_DESTINATION_NAME = "MAIL_SERVER_DESTINATION_NAME";
   private static final String DESTINATION_NAME = "test-destination";
 
-  MockedStatic<CloudPlatformDestinationFacade> cloudPlatformDestinationFacadeMock;
-  MockedStatic<Configuration>configurationMock;
+  private MockedStatic<CloudPlatformDestinationFacade> cloudPlatformDestinationFacadeMock;
+  private MockedStatic<Configuration>configurationMock;
 
   @Before
   public void setup() {


### PR DESCRIPTION
This PR makes it so that a destination wrapper object is returned in `getDestination`, in which we store host, port, pathPrefix and any other properties that the `cloudplatform.connectivity.Destination` object has (along with custom properties). 