### PR TITLE
Workflow minor improvement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,15 +31,19 @@ jobs:
           install: true
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
+        if: ${{ env.SONAR_TOKEN != '' }}
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Maven Build and Analyze
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn clean install -B sonar:sonar -Dsonar.projectKey=SAP_xsk
+        run: |
+          [ "$SONAR_TOKEN" ] && SONAR_ARG="-B sonar:sonar -Dsonar.projectKey=SAP_xsk"
+          mvn clean install $SONAR_ARG
       - name: Docker Login
         run: docker login -u ${{secrets.DOCKER_USER}} -p ${{secrets.DOCKER_PASSWORD}}
       - name: Push XSK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE_PREFIX: ${{ secrets.DOCKER_IMAGE_PREFIX }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -46,82 +48,81 @@ jobs:
           [ "$SONAR_TOKEN" ] && SONAR_ARG="-B sonar:sonar -Dsonar.projectKey=SAP_xsk"
           mvn clean install $SONAR_ARG
       - name: Docker Login
-        run: docker login -u ${{secrets.DOCKER_USER}} -p ${{secrets.DOCKER_PASSWORD}}
+        run: docker login -u ${{secrets.DOCKER_USER}} -p ${{secrets.DOCKER_PASSWORD}} ${{secrets.DOCKER_REGISTRY}}
       - name: Push XSK
         run: |
           cd releng/server
           cp -r "${JAVA_HOME}" jdk
-          docker build --load -t dirigiblelabs/xsk --build-arg JDK_TYPE=external-jdk --build-arg JDK_HOME=jdk .
-          docker push dirigiblelabs/xsk
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}xsk --build-arg JDK_TYPE=external-jdk --build-arg JDK_HOME=jdk .
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}xsk
           cd ../../
       - name: Push XSK for SAP Cloud Foundry
         run: |
           cd releng/sap-cf
           cp -r "${JAVA_HOME}" jdk
-          docker build --load -t dirigiblelabs/xsk-cf --build-arg JDK_TYPE=external-jdk --build-arg JDK_HOME=jdk .
-          docker push dirigiblelabs/xsk-cf
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}xsk-cf --build-arg JDK_TYPE=external-jdk --build-arg JDK_HOME=jdk .
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}xsk-cf
           cd ../../
       - name: Push XSK for SAP Kyma
         run: |
           cd releng/sap-kyma
           cp -r "${JAVA_HOME}" jdk
-          docker build --load -t dirigiblelabs/xsk-kyma --build-arg JDK_TYPE=external-jdk --build-arg JDK_HOME=jdk .
-          docker push dirigiblelabs/xsk-kyma
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}xsk-kyma --build-arg JDK_TYPE=external-jdk --build-arg JDK_HOME=jdk .
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}xsk-kyma
           cd ../../
       - uses: buildpacks/github-actions/setup-pack@v4.1.0
       - name: XSK Buildpack
         run: |
           cd releng/buildpacks/xsk/
-          docker build --load -t dirigiblelabs/buildpacks-stack-base-xsk . --target base
-          docker push dirigiblelabs/buildpacks-stack-base-xsk
-          docker build --load -t dirigiblelabs/buildpacks-stack-run-xsk . --target run
-          docker push dirigiblelabs/buildpacks-stack-run-xsk
-          docker build --load -t dirigiblelabs/buildpacks-stack-build-xsk . --target build
-          docker push dirigiblelabs/buildpacks-stack-build-xsk
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-base-xsk . --target base
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-base-xsk
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-run-xsk . --target run
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-run-xsk
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-build-xsk . --target build
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-build-xsk
           cd buildpack/
           find *.toml -type f -exec sed -i ''s/#{XSKVersion}#/latest/g'' {} \;
-          pack buildpack package dirigiblelabs/buildpacks-xsk --config ./package.toml
-          docker push dirigiblelabs/buildpacks-xsk
-          pack builder create dirigiblelabs/buildpacks-builder-xsk --config ./builder.toml
-          docker push dirigiblelabs/buildpacks-builder-xsk
+          pack buildpack package ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-xsk --config ./package.toml
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-xsk
+          pack builder create ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-builder-xsk --config ./builder.toml
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-builder-xsk
           cd ../../../../
       - name: XSK Kyma Buildpack
         run: |
           cd releng/buildpacks/xsk-kyma/
-          docker build --load -t dirigiblelabs/buildpacks-stack-base-xsk-kyma . --target base
-          docker push dirigiblelabs/buildpacks-stack-base-xsk-kyma
-          docker build --load -t dirigiblelabs/buildpacks-stack-run-xsk-kyma . --target run
-          docker push dirigiblelabs/buildpacks-stack-run-xsk-kyma
-          docker build --load -t dirigiblelabs/buildpacks-stack-build-xsk-kyma . --target build
-          docker push dirigiblelabs/buildpacks-stack-build-xsk-kyma
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-base-xsk-kyma . --target base
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-base-xsk-kyma
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-run-xsk-kyma . --target run
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-run-xsk-kyma
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-build-xsk-kyma . --target build
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-build-xsk-kyma
           cd buildpack/
           find *.toml -type f -exec sed -i ''s/#{XSKVersion}#/latest/g'' {} \;
-          pack buildpack package dirigiblelabs/buildpacks-xsk-kyma --config ./package.toml
-          docker push dirigiblelabs/buildpacks-xsk-kyma
-          pack builder create dirigiblelabs/buildpacks-builder-xsk-kyma --config ./builder.toml
-          docker push dirigiblelabs/buildpacks-builder-xsk-kyma
+          pack buildpack package ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-xsk-kyma --config ./package.toml
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-xsk-kyma
+          pack builder create ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-builder-xsk-kyma --config ./builder.toml
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-builder-xsk-kyma
           cd ../../../../
       - name: XSK Cloud Foundry Buildpack
         run: |
           cd releng/buildpacks/xsk-cf/
-          docker build --load -t dirigiblelabs/buildpacks-stack-base-xsk-cf . --target base
-          docker push dirigiblelabs/buildpacks-stack-base-xsk-cf
-          docker build --load -t dirigiblelabs/buildpacks-stack-run-xsk-cf . --target run
-          docker push dirigiblelabs/buildpacks-stack-run-xsk-cf
-          docker build --load -t dirigiblelabs/buildpacks-stack-build-xsk-cf . --target build
-          docker push dirigiblelabs/buildpacks-stack-build-xsk-cf
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-base-xsk-cf . --target base
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-base-xsk-cf
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-run-xsk-cf . --target run
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-run-xsk-cf
+          docker build --load -t ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-build-xsk-cf . --target build
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-stack-build-xsk-cf
           cd buildpack/
           find *.toml -type f -exec sed -i ''s/#{XSKVersion}#/latest/g'' {} \;
-          pack buildpack package dirigiblelabs/buildpacks-xsk-cf --config ./package.toml
-          docker push dirigiblelabs/buildpacks-xsk-cf
-          pack builder create dirigiblelabs/buildpacks-builder-xsk-cf --config ./builder.toml
-          docker push dirigiblelabs/buildpacks-builder-xsk-cf
+          pack buildpack package ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-xsk-cf --config ./package.toml
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-xsk-cf
+          pack builder create ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-builder-xsk-cf --config ./builder.toml
+          docker push ${DOCKER_IMAGE_PREFIX:-dirigiblelabs/}buildpacks-builder-xsk-cf
           cd ../../../../
       - name: Slack Notification
-        if: ${{ failure() }}
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
         uses: slackapi/slack-github-action@v1.14.0
         with:
           payload: "{\"type\":\"Build\",\"url\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: ${{ env.SLACK_WEBHOOK_URL != '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Maven Build and Analyze
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           [ "$SONAR_TOKEN" ] && SONAR_ARG="-B sonar:sonar -Dsonar.projectKey=SAP_xsk"
@@ -123,3 +124,4 @@ jobs:
           payload: "{\"type\":\"Build\",\"url\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -30,6 +30,7 @@ jobs:
           architecture: x64
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
+        if: ${{ env.SONAR_TOKEN != '' }}
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -38,7 +39,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn clean install -B sonar:sonar -Dsonar.projectKey=SAP_xsk
+        run: |
+          [ "$SONAR_TOKEN" ] && SONAR_ARG="-B sonar:sonar -Dsonar.projectKey=SAP_xsk"
+          mvn clean install $SONAR_ARG
       - name: Docker Build XSK
         run: |
           cd releng/server


### PR DESCRIPTION
Minor workflow improvement intended to allow forked repo build to happen without upstream Sonar access token and Slack notification URL defined.

Helps to stick to proper git workflow on github actions changes.

Docker images may now be pushed to 3rd party image registry to allow debug and testing, not tampering official 
docker registry.

DOCKER_REGISTRY action secret can be defined as used in docker login. If absent, `docker login` will happen
to default dockerhub image registry.

DOCKER_IMAGE_PREFIX action secret can be defined to override default image name prefix in a form of 
`$registryaddress/$prefix/` (with trailing slash). 

#### Changelog

**Changed**

* build workflow step `if` clause added for Slack notification
* maven build args related to Sonar made to be added conditionally
* DOCKER_REGISTRY action secret added to allow login to registry other than default (dockerhub)
* DOCKER_IMAGE_PREFIX action secret added to allow docker image path other than `dirigiblelabs/`
