### PR TITLE
Use keyGenerated field inside ODataEntityDefinition for calculation view generated keys

### DIFF
--- a/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/utils/XSKODataUtils.java
+++ b/modules/engines/engine-xsodata/src/main/java/com/sap/xsk/xsodata/utils/XSKODataUtils.java
@@ -130,7 +130,7 @@ public class XSKODataUtils {
       if (!entity.getKeyList().isEmpty()) {
         oDataEntityDefinition.setKeys(entity.getKeyList());
       } else if (entity.getKeyGenerated() != null) {
-        oDataEntityDefinition.getKeys().add(entity.getKeyGenerated());
+        oDataEntityDefinition.setKeyGenerated(entity.getKeyGenerated());
       }
 
       //process Aggregations


### PR DESCRIPTION
Depends on https://github.com/eclipse/dirigible/pull/1709
Resolves #1444 

Changelog:
1. XSKODataUtils now sets the generated key from the calculation view to the keyGenerated field inside ODataEntityDefinition.