### PR TITLE
chore: bump dependency versions

### DIFF
--- a/integration-tests/engine-hdb/pom.xml
+++ b/integration-tests/engine-hdb/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>io.github.hakky54</groupId>
             <artifactId>logcaptor</artifactId>
-            <version>2.7.9</version>
+            <version>${hakky.logcaptor.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,7 @@
         <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
         <javax.websocket-api.version>1.1</javax.websocket-api.version>
         <jacoco.version>0.8.8</jacoco.version>
+        <hakky.logcaptor.version>2.7.10</hakky.logcaptor.version>
 
         <profile.content.phase>none</profile.content.phase>
 

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <cxf.version>3.1.11</cxf.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>31.1-jre</guava.version>
-        <scp-cf.version>3.66.0</scp-cf.version>
+        <scp-cf.version>3.67.0</scp-cf.version>
         <slf4j.version>1.7.36</slf4j.version>
         <slf4j.simple.version>1.7.12</slf4j.simple.version>
         <logback.version>1.2.11</logback.version>
@@ -293,7 +293,7 @@
         <jaxb.version>2.3.0</jaxb.version>
         <jaxws.version>2.3.0</jaxws.version>
         <olingo.version>2.0.11</olingo.version>
-        <mockito.version>4.4.0</mockito.version>
+        <mockito.version>4.5.1</mockito.version>
         <junit.version>4.13.2</junit.version>
         <junitparams.version>1.1.1</junitparams.version>
         <hamcrest.all.version>1.3</hamcrest.all.version>
@@ -303,14 +303,14 @@
         <apache.httpclient.version>4.5.8</apache.httpclient.version>
         <commons.lang3>3.12.0</commons.lang3>
         <license-maven-plugin.version>4.2.rc3</license-maven-plugin.version>
-        <antlr4-runtime.version>4.9.3</antlr4-runtime.version>
-        <antlr4-maven-plugin.version>4.9.3</antlr4-maven-plugin.version>
+        <antlr4-runtime.version>4.10.1</antlr4-runtime.version>
+        <antlr4-maven-plugin.version>4.10.1</antlr4-maven-plugin.version>
         <selenium.version>4.1.3</selenium.version>
         <selenium.webdriver.manager.version>5.1.1</selenium.webdriver.manager.version>
         <neo-java-web-sdk.version>4.8.9</neo-java-web-sdk.version>
         <neo-java-web-sdk.javax.activation.version>1.2.0</neo-java-web-sdk.javax.activation.version>
         <neo-java-web-sdk.jaxb.version>2.2.11</neo-java-web-sdk.jaxb.version>
-        <ngdbc.version>2.12.7</ngdbc.version>
+        <ngdbc.version>2.12.9</ngdbc.version>
         <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
         <commons-csv.version>1.9.0</commons-csv.version>
         <commons-dbcp2.version>2.9.0</commons-dbcp2.version>


### PR DESCRIPTION
Bump `mockito`, `antlr`, `sap-cf`, `ngdbc` and `logcaptor` versions