### PR TITLE
revert: use antlr 4.9.3 as build fails with 4.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,8 +304,8 @@
         <apache.httpclient.version>4.5.8</apache.httpclient.version>
         <commons.lang3>3.12.0</commons.lang3>
         <license-maven-plugin.version>4.2.rc3</license-maven-plugin.version>
-        <antlr4-runtime.version>4.10.1</antlr4-runtime.version>
-        <antlr4-maven-plugin.version>4.10.1</antlr4-maven-plugin.version>
+        <antlr4-runtime.version>4.9.3</antlr4-runtime.version>
+        <antlr4-maven-plugin.version>4.9.3</antlr4-maven-plugin.version>
         <selenium.version>4.1.4</selenium.version>
         <selenium.webdriver.manager.version>5.1.1</selenium.webdriver.manager.version>
         <neo-java-web-sdk.version>4.8.9</neo-java-web-sdk.version>


### PR DESCRIPTION
The build fails with `4.10.1` so we should temporarily use `4.9.3` until the build issue is resolved.