### PR TITLE
fixup! Send slack notification only if slack hook url is defined

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,4 +154,3 @@ jobs:
           payload: "{\"type\":\"Build\",\"url\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: ${{ env.SLACK_WEBHOOK_URL != '' }}


### PR DESCRIPTION
Fixes error made during PR #1565 cleanup and rebase process