### PR TITLE
fix: handle path for single resource publish

### DIFF
--- a/modules/engines/engine-xsjs/src/main/java/com/sap/xsk/synchronizer/XSJSLibSynchronizer.java
+++ b/modules/engines/engine-xsjs/src/main/java/com/sap/xsk/synchronizer/XSJSLibSynchronizer.java
@@ -30,18 +30,18 @@ public class XSJSLibSynchronizer extends AbstractSynchronizer implements IOrdere
 
   public static final String XSJSLIB_SYNCHRONIZER_STATE_TABLE_NAME = "PROCESSED_XSJSLIB_ARTEFACTS";
 
-  private final String targetLocation;
+  private final String targetRegistryPath;
 
   public XSJSLibSynchronizer() {
     this(XSKCommonsConstants.XSK_REGISTRY_PUBLIC);
   }
 
-  public XSJSLibSynchronizer(String targetLocation) {
-    this.targetLocation = targetLocation;
+  public XSJSLibSynchronizer(String targetRegistryPath) {
+    this.targetRegistryPath = targetRegistryPath;
   }
 
-  public static void forceSynchronization(String targetLocation) {
-    XSJSLibSynchronizer synchronizer = new XSJSLibSynchronizer(targetLocation);
+  public static void forceSynchronization(String targetRegistryPath) {
+    XSJSLibSynchronizer synchronizer = new XSJSLibSynchronizer(targetRegistryPath);
     synchronizer.setForcedSynchronization(true);
     try {
       synchronizer.synchronize();
@@ -54,7 +54,7 @@ public class XSJSLibSynchronizer extends AbstractSynchronizer implements IOrdere
     logger.trace("Synchronizing XSJSLibs...");
 
     Map<Object, Object> context = new HashMap<>();
-    context.put("targetRegistryPath", targetLocation);
+    context.put("targetRegistryPath", targetRegistryPath);
     context.put("stateTableName", XSJSLIB_SYNCHRONIZER_STATE_TABLE_NAME);
 
     GraalVMJavascriptEngineExecutor graalVMJavascriptEngineExecutor = new GraalVMJavascriptEngineExecutor();

--- a/modules/engines/engine-xsjs/src/main/resources/META-INF/dirigible/exports/XSJSLibExportsGenerator.mjs
+++ b/modules/engines/engine-xsjs/src/main/resources/META-INF/dirigible/exports/XSJSLibExportsGenerator.mjs
@@ -1,6 +1,7 @@
 import { XSJSLibContentModifier } from '/exports/XSJSLibContentModifier.mjs'
 import { XSJSLibArtefactStateTable } from '/exports/XSJSLibArtefactStateTable.mjs'
 import { digest } from '@dirigible-v4/utils'
+import { repository } from '@dirigible-v4/platform'
 
 export class XSJSLibExportsGenerator {
 
@@ -13,12 +14,23 @@ export class XSJSLibExportsGenerator {
     );
   }
 
-  run(targetRegistryCollection) {
-    this._generateExportsRecursively(targetRegistryCollection);
+  run(targetPath) {
+    const targetResource = repository.getResource(targetPath);
+    const targetCollection = repository.getCollection(targetPath);
+
+    if(targetResource.exists()) {
+      this._checkTableAndGenerateExportsIfNeeded(targetResource);
+    }
+    else if(targetCollection.exists()) {
+      this._generateExportsRecursively(targetCollection);
+    }
+    else {
+      throw new Error("XSJSLibSynchronizer repository target not found at: " + targetPath);
+    }
   }
 
   _generateExportsRecursively(parentCollection) {
-    if (!parentCollection.exists() || !this.processedArtefactsTable) {
+    if (!parentCollection.exists()) {
       throw new Error("Collection not found: " + parentCollection.getPath());
     }
 
@@ -48,12 +60,23 @@ export class XSJSLibExportsGenerator {
   }
 
   _checkTableAndGenerateExportsIfNeeded(resource) {
+    if(!resource.exists()) {
+      throw new Error("XSJSLibSynchronizer resource not found.");
+    }
+
+    if(!resource.getPath().endsWith(".xsjslib")) {
+      return;
+    }
+
+    if (!this.processedArtefactsTable) {
+      throw new Error("XSJSLibSynchronizer state table not found.");
+    }
+
     const content = resource.getText();
     const location = resource.getPath();
+    const foundEntry = this.processedArtefactsTable.findEntryByResourceLocation(location);
 
     const contentModifier = new XSJSLibContentModifier();
-
-    const foundEntry = this.processedArtefactsTable.findEntryByResourceLocation(location);
 
     if (!foundEntry) {
         const contentWithExports = contentModifier.writeExportsToResource(resource, content);

--- a/modules/engines/engine-xsjs/src/main/resources/META-INF/dirigible/exports/XSJSLibRunGeneration.mjs
+++ b/modules/engines/engine-xsjs/src/main/resources/META-INF/dirigible/exports/XSJSLibRunGeneration.mjs
@@ -11,13 +11,10 @@
  */
 
 import { XSJSLibExportsGenerator } from '/exports/XSJSLibExportsGenerator.mjs'
-const repository = require('platform/v4/repository');
-
-const targetRegistryCollection = repository.getCollection(__context.targetRegistryPath);
 const stateTableParams = {
   name: __context.stateTableName,
   schema: "PUBLIC"
 }
 
 const generator = new XSJSLibExportsGenerator(stateTableParams);
-generator.run(targetRegistryCollection);
+generator.run(__context.targetRegistryPath);

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/exports/multiFileExportGenerationTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/exports/multiFileExportGenerationTest.mjs
@@ -23,7 +23,7 @@ function testMultiFileFolderExportGeneration() {
 
   // run generation and assert content is valid for all resources
   const generator = new XSJSLibExportsGenerator(stateTableParams);
-  generator.run(baseCollection);
+  generator.run(baseCollection.getPath());
   assertEquals(baseExpectedContent, baseResource.getText(), "Unexpected xsjslib content after exports generation.");
   assertEquals(childExpectedContent, childResource.getText(), "Unexpected xsjslib content after exports generation.");
 

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/exports/singleFileExportGenerationTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/exports/singleFileExportGenerationTest.mjs
@@ -16,7 +16,7 @@ function testSingleFileExportGeneration() {
 
   // run generation and assert content is valid
   const generator = new XSJSLibExportsGenerator(stateTableParams);
-  generator.run(collection);
+  generator.run(collection.getPath());
   assertEquals(expectedContent, resource.getText(), "Unexpected xsjslib content after exports generation.");
 
   // assert state table entries are okay

--- a/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/exports/singleFileExportUpdateTest.mjs
+++ b/modules/engines/engine-xsjs/src/test/resources/META-INF/dirigible/test/xsk/exports/singleFileExportUpdateTest.mjs
@@ -19,7 +19,7 @@ function testSingleFileExportUpdate() {
 
   // run generation to update the content and state table and assert content is valid
   const generator = new XSJSLibExportsGenerator(stateTableParams);
-  generator.run(collection);
+  generator.run(collection.getPath());
   assertEquals(expectedContent, resource.getText(), "Unexpected xsjslib content after exports generation.");
 
   // assert state table entries are okay


### PR DESCRIPTION
Resolves issue on publish of a single xsjslib, where the xsjslib synchronizer forceSynchronize failed due to it expecting a collection.