### PR TITLE
build: use maven revision for modules versioning

### DIFF
--- a/coverage-aggregate/pom.xml
+++ b/coverage-aggregate/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Coverage Aggregate</name>
     <artifactId>xsk-coverage-aggregate</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <description>Aggregate Coverage Report</description>
 
     <dependencies>

--- a/integration-tests/applications/pom.xml
+++ b/integration-tests/applications/pom.xml
@@ -5,21 +5,21 @@
   <parent>
     <artifactId>xsk-integration-tests-parent</artifactId>
     <groupId>com.sap.xsk</groupId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <name>XSK - Integration Tests - Applications</name>
   <artifactId>xsk-integration-tests-applications</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>integration-tests-core</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/engine-hdb/pom.xml
+++ b/integration-tests/engine-hdb/pom.xml
@@ -5,20 +5,20 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-integration-tests-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Integration Tests - Engines - HDB</name>
     <artifactId>xsk-integration-tests-engines-hdb</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-engines-hdb</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 
@@ -87,27 +87,27 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbti</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbsequence</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbschema</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbtable</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbdd</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>

--- a/integration-tests/integration-tests-core/pom.xml
+++ b/integration-tests/integration-tests-core/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <artifactId>xsk-integration-tests-parent</artifactId>
     <groupId>com.sap.xsk</groupId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <name>XSK - Integration Tests - Core</name>
   <artifactId>integration-tests-core</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -6,13 +6,13 @@
   <parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Integration Tests - Parent</name>
 	<artifactId>xsk-integration-tests-parent</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>pom</packaging>
 
 	<modules>
@@ -23,6 +23,7 @@
   </modules>
 
 	<properties>
+    <revision>0.17.0-SNAPSHOT</revision>
 		<license.header.location>../licensing-header.txt</license.header.location>
 	</properties>
 

--- a/integration-tests/ui/pom.xml
+++ b/integration-tests/ui/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-integration-tests-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Integration Tests - UI</name>
   <artifactId>xsk-integration-tests-ui</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>integration-tests-core</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/modules/all/pom.xml
+++ b/modules/all/pom.xml
@@ -5,34 +5,34 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-modules-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 
 	<name>XSK - Modules - All</name>
 	<artifactId>xsk-modules-all</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>jar</packaging>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-api-all</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-engines-all</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-all</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-ide-all</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 	</dependencies>
 

--- a/modules/api/api-all/pom.xml
+++ b/modules/api/api-all/pom.xml
@@ -5,20 +5,20 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-modules-api-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Modules - API - All</name>
 	<artifactId>xsk-modules-api-all</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>jar</packaging>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-api-xsjs</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 	</dependencies>
 

--- a/modules/api/api-xsjs/pom.xml
+++ b/modules/api/api-xsjs/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-modules-api-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Modules - API - XSJS</name>
   <artifactId>xsk-modules-api-xsjs</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/modules/api/pom.xml
+++ b/modules/api/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-modules-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Modules - API - Parent</name>
 	<artifactId>xsk-modules-api-parent</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/modules/engines/engine-all/pom.xml
+++ b/modules/engines/engine-all/pom.xml
@@ -5,59 +5,59 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-modules-engines-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 
 	<name>XSK - Modules - Engines - All</name>
 	<artifactId>xsk-modules-engines-all</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>jar</packaging>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-engines-core</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-engines-hdb</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-engines-hdbti</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-engines-hdi</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-engines-xsjob</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-engines-xsjs</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-engines-xsodata</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-engines-xssecurity</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-engines-mail-destination</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 	</dependencies>
 

--- a/modules/engines/engine-commons/pom.xml
+++ b/modules/engines/engine-commons/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-engines-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - Engines - Commons</name>
     <artifactId>xsk-modules-engines-commons</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-commons</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/modules/engines/engine-core/pom.xml
+++ b/modules/engines/engine-core/pom.xml
@@ -7,25 +7,25 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-engines-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - Engines - Core</name>
     <artifactId>xsk-modules-engines-core</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-all</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-api-all</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>
@@ -129,25 +129,25 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbti</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-hdbsequence</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 			<scope>compile</scope>
 		</dependency>
         <dependency>
 			<groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbtable</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 			<scope>compile</scope>
 		</dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-engines-hdb</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/modules/engines/engine-hdb/pom.xml
+++ b/modules/engines/engine-hdb/pom.xml
@@ -7,25 +7,25 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-modules-engines-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Modules - Engines - HDB</name>
   <artifactId>xsk-modules-engines-hdb</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-engines-commons</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-all</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <exclusions>
         <exclusion>
           <groupId>log4j</groupId>
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-api-all</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>
@@ -169,31 +169,31 @@
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbti</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbsequence</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbschema</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbtable</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbdd</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
       <dependency>

--- a/modules/engines/engine-hdbti/pom.xml
+++ b/modules/engines/engine-hdbti/pom.xml
@@ -7,35 +7,35 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-modules-engines-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Modules - Engines - HDBTI</name>
   <artifactId>xsk-modules-engines-hdbti</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-engines-core</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-engines-hdb</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-all</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-api-all</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbti</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -162,13 +162,13 @@
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbsequence</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbtable</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/engines/engine-hdi/pom.xml
+++ b/modules/engines/engine-hdi/pom.xml
@@ -7,30 +7,30 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-engines-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - Engines - HDI</name>
     <artifactId>xsk-modules-engines-hdi</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <dependencies>
     	<dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-engines-hdb</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-all</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-api-all</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>
@@ -134,19 +134,19 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbti</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-hdbsequence</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 			<scope>compile</scope>
 		</dependency>
         <dependency>
 			<groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbtable</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/modules/engines/engine-mail-destination/pom.xml
+++ b/modules/engines/engine-mail-destination/pom.xml
@@ -7,13 +7,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-modules-engines-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Modules - Mail - Destination</name>
   <artifactId>xsk-modules-engines-mail-destination</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -25,7 +25,7 @@
     <dependency>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-api-xsjs</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sap.cloud.sdk.cloudplatform</groupId>

--- a/modules/engines/engine-xsjob/pom.xml
+++ b/modules/engines/engine-xsjob/pom.xml
@@ -7,35 +7,35 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-engines-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - Engines - XS Job</name>
     <artifactId>xsk-modules-engines-xsjob</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <dependencies>
     	<dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-engines-core</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
     	<dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-engines-xsjs</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-all</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-api-all</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>
@@ -145,19 +145,19 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbti</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-hdbsequence</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 			<scope>compile</scope>
 		</dependency>
         <dependency>
 			<groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbtable</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/modules/engines/engine-xsjs/pom.xml
+++ b/modules/engines/engine-xsjs/pom.xml
@@ -7,25 +7,25 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-modules-engines-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Modules - Engines - XS JS</name>
   <artifactId>xsk-modules-engines-xsjs</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-all</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-api-all</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -136,19 +136,19 @@
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbti</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbsequence</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hdbtable</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/modules/engines/engine-xsodata/pom.xml
+++ b/modules/engines/engine-xsodata/pom.xml
@@ -7,30 +7,30 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-modules-engines-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Modules - Engines - XS OData</name>
   <artifactId>xsk-modules-engines-xsodata</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-xsodata</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-api-all</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-engines-commons</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.dirigible</groupId>

--- a/modules/engines/engine-xssecurity/pom.xml
+++ b/modules/engines/engine-xssecurity/pom.xml
@@ -7,30 +7,30 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-engines-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - Engines - XS Security</name>
     <artifactId>xsk-modules-engines-xssecurity</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <dependencies>
     	<dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-engines-core</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-all</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-api-all</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>
@@ -134,19 +134,19 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbti</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-hdbsequence</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 			<scope>compile</scope>
 		</dependency>
         <dependency>
 			<groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-hdbtable</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/modules/engines/pom.xml
+++ b/modules/engines/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-modules-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Modules - Engines - Parent</name>
 	<artifactId>xsk-modules-engines-parent</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/modules/ide/ide-all/pom.xml
+++ b/modules/ide/ide-all/pom.xml
@@ -5,50 +5,50 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-ide-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - IDE - All</name>
     <artifactId>xsk-modules-ide-all</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-ide-migration</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-ide-file-types</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-ide-hdbti</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-ide-xsk-workspace-menu</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-ide-xsk-ide-xsjob</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-ide-xsk-ide-hdi</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
           <groupId>com.sap.xsk</groupId>
           <artifactId>xsk-modules-xsk-ide-xsaccess</artifactId>
-          <version>0.17.0-SNAPSHOT</version>
+          <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/modules/ide/ide-file-types/pom.xml
+++ b/modules/ide/ide-file-types/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-ide-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - IDE - HDBTI</name>
     <artifactId>xsk-modules-ide-file-types</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/modules/ide/ide-hdbti/pom.xml
+++ b/modules/ide/ide-hdbti/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-ide-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - IDE - HDBTI</name>
     <artifactId>xsk-modules-ide-hdbti</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/modules/ide/ide-migration/pom.xml
+++ b/modules/ide/ide-migration/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-ide-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - IDE - Migration</name>
     <artifactId>xsk-modules-ide-migration</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-engines-xsjs</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-engines-hdb</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/modules/ide/pom.xml
+++ b/modules/ide/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - IDE - Parent</name>
     <artifactId>xsk-modules-ide-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/modules/ide/xsk-ide-hdi/pom.xml
+++ b/modules/ide/xsk-ide-hdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>xsk-modules-ide-parent</artifactId>
         <groupId>com.sap.xsk</groupId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/modules/ide/xsk-ide-xsaccess/pom.xml
+++ b/modules/ide/xsk-ide-xsaccess/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>xsk-modules-ide-parent</artifactId>
         <groupId>com.sap.xsk</groupId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/modules/ide/xsk-ide-xsjob/pom.xml
+++ b/modules/ide/xsk-ide-xsjob/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xsk-modules-ide-parent</artifactId>
     <groupId>com.sap.xsk</groupId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/modules/ide/xsk-workspace-menu/pom.xml
+++ b/modules/ide/xsk-workspace-menu/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xsk-modules-ide-parent</artifactId>
     <groupId>com.sap.xsk</groupId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/modules/parsers/parser-all/pom.xml
+++ b/modules/parsers/parser-all/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-modules-parsers-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Modules - Parsers - All</name>
 	<artifactId>xsk-modules-parsers-all</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>jar</packaging>
 
 	<dependencies>
@@ -23,42 +23,42 @@
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-commons</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-xsodata</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-hdbti</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-hdbtable</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-hdbview</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-hdbsequence</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-modules-parsers-hdbschema</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-parsers-hana</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 	</dependencies>
 

--- a/modules/parsers/parser-calculationview/pom.xml
+++ b/modules/parsers/parser-calculationview/pom.xml
@@ -7,13 +7,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-modules-parsers-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Modules - Parsers - Calculation View</name>
   <artifactId>xsk-modules-parsers-calculationview</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-engines-commons</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/modules/parsers/parser-commons/pom.xml
+++ b/modules/parsers/parser-commons/pom.xml
@@ -7,13 +7,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-modules-parsers-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Modules - Parsers - Commons</name>
   <artifactId>xsk-modules-parsers-commons</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/modules/parsers/parser-hana/pom.xml
+++ b/modules/parsers/parser-hana/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-parsers-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>XSK - Modules - Parsers - Hana</name>
     <artifactId>xsk-modules-parsers-hana</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-commons</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/modules/parsers/parser-hdbcalculationview/pom.xml
+++ b/modules/parsers/parser-hdbcalculationview/pom.xml
@@ -7,13 +7,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-modules-parsers-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Modules - Parsers - HDB Calculation View</name>
   <artifactId>xsk-modules-parsers-hdbcalculationview</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.sap.xsk</groupId>
       <artifactId>xsk-modules-engines-commons</artifactId>
-      <version>0.17.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 

--- a/modules/parsers/parser-hdbdd/pom.xml
+++ b/modules/parsers/parser-hdbdd/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-parsers-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <name>XSK - Modules - Parsers - HDBDD</name>
     <artifactId>xsk-modules-parsers-hdbdd</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-commons</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/modules/parsers/parser-hdbschema/pom.xml
+++ b/modules/parsers/parser-hdbschema/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-parsers-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>XSK - Modules - Parsers - HDB Schema</name>
     <artifactId>xsk-modules-parsers-hdbschema</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-commons</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/modules/parsers/parser-hdbsequence/pom.xml
+++ b/modules/parsers/parser-hdbsequence/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-parsers-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>XSK - Modules - Parsers - HDB Sequence</name>
     <artifactId>xsk-modules-parsers-hdbsequence</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-commons</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/modules/parsers/parser-hdbtable/pom.xml
+++ b/modules/parsers/parser-hdbtable/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-parsers-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>XSK - Modules - Parsers - HDB Table</name>
     <artifactId>xsk-modules-parsers-hdbtable</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-commons</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/modules/parsers/parser-hdbti/pom.xml
+++ b/modules/parsers/parser-hdbti/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-parsers-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>XSK - Modules - Parsers - HDB Table Import</name>
     <artifactId>xsk-modules-parsers-hdbti</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-engines-commons</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>

--- a/modules/parsers/parser-hdbview/pom.xml
+++ b/modules/parsers/parser-hdbview/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-parsers-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>XSK - Modules - Parsers - HDB View</name>
     <artifactId>xsk-modules-parsers-hdbview</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-commons</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/modules/parsers/parser-xsodata/pom.xml
+++ b/modules/parsers/parser-xsodata/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>com.sap.xsk</groupId>
         <artifactId>xsk-modules-parsers-parent</artifactId>
-        <version>0.17.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>XSK - Modules - Parsers - XS OData</name>
     <artifactId>xsk-modules-parsers-xsodata</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.sap.xsk</groupId>
             <artifactId>xsk-modules-parsers-commons</artifactId>
-            <version>0.17.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/modules/parsers/pom.xml
+++ b/modules/parsers/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-modules-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Modules - Parsers - Parent</name>
 	<artifactId>xsk-modules-parsers-parent</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Modules - Parent</name>
 	<artifactId>xsk-modules-parent</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
 
 
         <dirigible.version>6.2.29</dirigible.version>
-        <revision>0.170.0-SNAPSHOT</revision>
+        <revision>1.0.0-dev</revision>
 
 
         <!-- Sonar Cloud -->

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <description>XSK - HANA XS Classic Compatibility Environment</description>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <inceptionYear>2019</inceptionYear>
@@ -254,6 +254,7 @@
 
 
         <dirigible.version>6.2.29</dirigible.version>
+        <revision>0.170.0-SNAPSHOT</revision>
 
 
         <!-- Sonar Cloud -->

--- a/releng/buildpacks/pom.xml
+++ b/releng/buildpacks/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-releng-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Releng - Buildpacks - Parent</name>
 	<artifactId>xsk-releng-buildpacks-parent</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/releng/buildpacks/xsk-cf/pom.xml
+++ b/releng/buildpacks/xsk-cf/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-releng-buildpacks-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Releng - Buildpacks - XSK Cloud Foundry</name>
   <artifactId>xsk-releng-buildpacks-xsk-cf</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
 
   <build>
     <finalName>${project.artifactId}</finalName>

--- a/releng/buildpacks/xsk-kyma-runtime/pom.xml
+++ b/releng/buildpacks/xsk-kyma-runtime/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-releng-buildpacks-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Releng - Buildpacks - XSK Kyma</name>
   <artifactId>xsk-releng-buildpacks-xsk-kyma-runtime</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
 
   <build>
     <finalName>${project.artifactId}</finalName>

--- a/releng/buildpacks/xsk-kyma/pom.xml
+++ b/releng/buildpacks/xsk-kyma/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-releng-buildpacks-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Releng - Buildpacks - XSK Kyma</name>
   <artifactId>xsk-releng-buildpacks-xsk-kyma</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
 
   <build>
     <finalName>${project.artifactId}</finalName>

--- a/releng/buildpacks/xsk/pom.xml
+++ b/releng/buildpacks/xsk/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-releng-buildpacks-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Releng - Buildpacks - XSK</name>
   <artifactId>xsk-releng-buildpacks-xsk</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
 
   <build>
     <finalName>${project.artifactId}</finalName>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Releng - Parent</name>
 	<artifactId>xsk-releng-parent</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/releng/sap-cf/pom.xml
+++ b/releng/sap-cf/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-releng-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Releng - Cloud Foundry</name>
 	<artifactId>xsk-releng-cf</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>war</packaging>
 
 	<build>

--- a/releng/sap-kyma-runtime/pom.xml
+++ b/releng/sap-kyma-runtime/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-releng-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Releng - Kyma</name>
 	<artifactId>xsk-releng-kyma-runtime</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>war</packaging>
 
 	<build>

--- a/releng/sap-kyma/pom.xml
+++ b/releng/sap-kyma/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-releng-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Releng - Kyma</name>
 	<artifactId>xsk-releng-kyma</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>war</packaging>
 
 	<build>

--- a/releng/server/pom.xml
+++ b/releng/server/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-releng-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Releng - Server</name>
 	<artifactId>xsk-releng-server</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>war</packaging>
 
 	<build>

--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Resources - Parent</name>
 	<artifactId>xsk-resources-parent</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/resources/resources-all/pom.xml
+++ b/resources/resources-all/pom.xml
@@ -5,25 +5,25 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-resources-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Resources - All</name>
 	<artifactId>xsk-resources-all</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>jar</packaging>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-resources-neo-sdk</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.xsk</groupId>
 			<artifactId>xsk-resources-neo-sdk-synchronizer</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 	</dependencies>
 

--- a/resources/resources-neo-sdk-synchronizer/pom.xml
+++ b/resources/resources-neo-sdk-synchronizer/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>com.sap.xsk</groupId>
 		<artifactId>xsk-resources-parent</artifactId>
-		<version>0.17.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>XSK - Resources - Neo SDK - Synchronizer</name>
 	<artifactId>xsk-resources-neo-sdk-synchronizer</artifactId>
-	<version>0.17.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/resources/resources-neo-sdk/pom.xml
+++ b/resources/resources-neo-sdk/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>com.sap.xsk</groupId>
     <artifactId>xsk-resources-parent</artifactId>
-    <version>0.17.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <name>XSK - Resources - Neo SDK</name>
   <artifactId>xsk-resources-neo-sdk</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <build>


### PR DESCRIPTION
Currently, when making a release, we change manually the versions of all maven modules. I think it would be easier to use the approach defined here: https://maven.apache.org/maven-ci-friendly.html

By doing this, we can easily configure the version we want when building: `mvn clean install -Drevision=1.2.3-SNAPSHOT`. I think this would also be necessary for https://github.com/SAP/xsk/issues/1645
