### PR TITLE
feat: use nightly built XSK image for selenium tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,14 +10,6 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
 
-    # Download latest DockerHub image of XSK and run it in a service container
-    # that is available to the steps below via 127.0.0.1:8080
-    services:
-      xsk:
-        image: dirigiblelabs/xsk
-        ports:
-          - 8080:8080
-
     steps:
       # Checkout
       - uses: actions/checkout@v2
@@ -51,7 +43,17 @@ jobs:
       - name: Verify Firefox
         run: firefox --version
 
-      # Wait for XSK Service Container to Startup
+      # Build and Run XSK
+      - name: Build XSK
+        run: mvn clean install
+
+      - name: Docker Build XSK
+        run: docker build -t dirigiblelabs/xsk-selenium-build /home/runner/work/xsk/xsk/releng/server/.
+
+      - name: Docker Run XSK
+        run: docker run -d --name dirigible --rm -e JPDA_ADDRESS=0.0.0.0:8000 -e JPDA_TRANSPORT=dt_socket -p 8000:8000 -p 8080:8080 -p 8081:8081 -p 9229:9229 dirigiblelabs/xsk-selenium-build
+
+      # Wait for XSK to Startup
       - name: Wait XSK Startup
         uses: nick-invision/retry@v2
         with:
@@ -60,11 +62,7 @@ jobs:
           warning_on_retry: false
           command: curl -m 5 --silent --fail --request GET http://127.0.0.1:8080/services/v4/healthcheck | jq --exit-status -n 'inputs | if has("status") then .status=="Ready" else false end' > /dev/null
 
-      # Build XSK
-      - name: Build XSK
-        run: mvn clean install
-
-      # Run Selenium tests on XSK
+      # Run Selenium tests on locally running XSK
       - name: Run Integration & Selenium Tests
         working-directory: ./integration-tests
         run: mvn clean test -P itests -fae -Dhana.url="${{secrets.ITESTS_HANA_URL}}" -Dhana.username="${{secrets.ITESTS_HANA_USERNAME}}" -Dhana.password="${{secrets.ITESTS_HANA_PASSWORD}}"


### PR DESCRIPTION
Currently the Nightly GitHub action runs the selenium tests against a locally (to the action workflow) running XSK that is started from the dirigiblelabs/xsk image on DockerHub.
- This PR makes the Nightly run XSK with the image that was locally (to the action workflow) built.
- Doing it this way the Selenium tests can be ran on PR, because the PR branch's code base will be used to build the image and the Selenium tests will run against it.
- Sample workflow run [here](https://github.com/SAP/xsk/runs/6781865011?check_suite_focus=true). *:warning:The sample run failed due to changes in the migration UI, not the changes in this PR.*

Fixes: https://github.com/SAP/xsk/issues/1626