### PR TITLE
feat: speedup selenium test and remove thread.sleep() calls

### DIFF
--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/WebBrowser.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/WebBrowser.java
@@ -14,6 +14,7 @@ package com.xsk.integration.tests.migration;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
+import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -172,6 +173,41 @@ class WebBrowser {
 
   List<WebElement> findElementsBy(By by) {
     return browser.findElements(by);
+  }
+
+  String retryJavascriptWithTimeout(String javascript, int timeoutMs, int retries) {
+    int intervalMs = timeoutMs / retries, initialRetries = retries;
+    do {
+      try {
+        System.out.println(
+            "[Selenium - Retry Javascript With Timeout] Running Attempt "
+            + (initialRetries - retries + 1) + " for call '" + javascript +"'"
+        );
+
+        String result = this.executeJavascript(javascript);
+
+        System.out.println(
+            "[Selenium - Retry Javascript With Timeout] Success at attempt "
+            + (initialRetries - retries + 1) + " for call '" + javascript + "'"
+        );
+
+        return result;
+      } catch(JavascriptException exception) {
+        System.out.println(
+            "[Selenium - Retry Javascript With Timeout] Attempt Failed "
+            + (initialRetries - retries + 1) + " for call '" + javascript
+            + "' sleeping for " + intervalMs + " ms."
+        );
+
+        retries--;
+        this.sleep(intervalMs);
+      }
+    } while(retries > 0);
+
+    throw new RuntimeException(
+        "Retry WebBrowser::JavascriptWithTimeout(String, int, int) failed after timeout was reached. "
+        + "Arguments were: \n javascript:" + javascript + "\n timeout: " + timeoutMs + "\n retries: " + initialRetries
+    );
   }
 
   void sleep(long millis) throws RuntimeException {


### PR DESCRIPTION
This PR fixes https://github.com/SAP/xsk/issues/1627 by adding a retry mechanic to web browser javascript execution calls for the selenium test.
- The execution time of the selenium tests with both browsers is reduced by half!
- Before test execution took ~4min 30sec per browser => ~9min total
- Now test execution takes ~2min 30sec per browser => 5min total
- Possible flakiness due to execution on slower computer that would not load before the thread sleep was over is also resolved.