### PR TITLE
chore: update dirigible version and remove migrations apache cxf dep

### DIFF
--- a/modules/ide/ide-migration/pom.xml
+++ b/modules/ide/ide-migration/pom.xml
@@ -17,11 +17,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-core</artifactId>
-            <version>3.5.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-api</artifactId>
             <version>${dirigible.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 
-        <dirigible.version>6.3.6</dirigible.version>
+        <dirigible.version>6.3.7</dirigible.version>
 
 
         <!-- Sonar Cloud -->


### PR DESCRIPTION
This PR updates the Dirigible version to `6.3.7` and removes an unnecessary `cxf-core` dependency in the migrations module