### PR TITLE
fix: selenium bypass context menu when opening files and log dropdown items

### DIFF
--- a/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
+++ b/integration-tests/ui/src/test/java/com/xsk/integration/tests/migration/MigrationITest.java
@@ -102,7 +102,11 @@ public class MigrationITest {
 
   private void enterNeoDBTunnelCredentials() {
     webBrowser.enterAndAssertField(By.id("subaccount"), credentials.getSubaccount());
-    webBrowser.selectAndAssertDropdown("regionList", (item) -> item.contains(credentials.getRegion()));
+    webBrowser.selectAndAssertDropdown("regionList", item -> {
+      boolean result = item.contains(credentials.getRegion());
+      System.out.println("[selectAndAssertDropdown] regionList Dropdown item " + item + " contains " + credentials.getRegion() + " is " + result);
+      return result;
+    });
     webBrowser.enterAndAssertField(By.id("neo-username"), credentials.getUsername());
     webBrowser.enterAndAssertField(By.id("neo-password"), credentials.getPassword());
     webBrowser.log();
@@ -110,7 +114,12 @@ public class MigrationITest {
   }
 
   private void enterHanaCredentials() {
-    webBrowser.selectAndAssertDropdown("databasesList", (item) -> item.equals(credentials.getSchema()));
+    webBrowser.selectAndAssertDropdown("databasesList", item -> {
+      boolean result = item.contains(credentials.getSchema());
+      System.out.println("[selectAndAssertDropdown] databasesList Dropdown item " + item + " contains " + credentials.getSchema() + " is " + result);
+      return result;
+    });
+
     webBrowser.enterAndAssertField(By.id("username"), credentials.getHanaUsername());
     webBrowser.enterAndAssertField(By.id("password"), credentials.getHanaPassword());
     webBrowser.log();
@@ -118,8 +127,18 @@ public class MigrationITest {
   }
 
   private void selectDeliveryUnits() {
-    webBrowser.selectAndAssertDropdown("workspacesList", (item) -> item.equals(expectedContentProvider.getExpectedWorkspaceName()));
-    webBrowser.selectAndAssertDropdown("deliveryUnitList", (item) -> item.equals(expectedContentProvider.getExpectedDeliveryUnitName()));
+    webBrowser.selectAndAssertDropdown("workspacesList", item -> {
+      boolean result = item.contains(expectedContentProvider.getExpectedWorkspaceName());
+      System.out.println("[selectAndAssertDropdown] workspacesList Dropdown item " + item
+          + " contains " + expectedContentProvider.getExpectedWorkspaceName() + " is " + result);
+      return result;
+    });
+    webBrowser.selectAndAssertDropdown("deliveryUnitList", item -> {
+      boolean result = item.contains(expectedContentProvider.getExpectedDeliveryUnitName());
+      System.out.println("[selectAndAssertDropdown] deliveryUnitList Dropdown item " + item
+          + " contains " + expectedContentProvider.getExpectedDeliveryUnitName() + " is " + result);
+      return result;
+    });
     webBrowser.clickItem(By.xpath("//*[@ng-disabled=\"duDropdownDisabled\"]"));
     webBrowser.log();
     webBrowser.clickItem(By.xpath("//*[@ng-click=\"goForward()\"]"));
@@ -183,23 +202,7 @@ public class MigrationITest {
     var fileAnchor = fileAnchors.get(0);
 
     // Open the file by clicking on the jstree node or via context menu.
-    if (isNonTextEditorFile(file.getFilePath())) {
-      webBrowser.scrollIntoView(fileAnchor);
-      webBrowser.contextClick(fileAnchor);
-      webBrowser.switchToDefaultContent();
-
-      String openWithMenuItemXpath = "//*[text()='Open With']";
-      String codeEditorMenuItemXpath = "//*[text()='Code Editor']";
-
-      webBrowser.moveTo(By.xpath(openWithMenuItemXpath));
-      webBrowser.clickItem(By.xpath(openWithMenuItemXpath));
-
-      webBrowser.moveTo(By.xpath(codeEditorMenuItemXpath));
-      webBrowser.clickItem(By.xpath(codeEditorMenuItemXpath));
-
-      webBrowser.switchToIframe(By.xpath("//iframe[@src='../ide-projects/projects.html']"));
-      webBrowser.waitForVisibilityOfElement(By.id("j1_1_anchor"));
-    } else {
+    if (!isNonTextEditorFile(file.getFilePath())) {
       webBrowser.scrollIntoView(fileAnchor);
       webBrowser.doubleClickItem(fileAnchor);
     }
@@ -219,6 +222,8 @@ public class MigrationITest {
       if (collectionHasElementEndingWith(fileQueryParameter, filePath)) {
         if (isImageFile(filePath)) {
           assertImageFileEquals(iframe, file);
+        } else if(isNonTextEditorFile(filePath)) {
+          assertTextEquals(file, filePath);
         } else {
           assertMonacoTextFileEquals(iframe, file);
         }
@@ -288,27 +293,38 @@ public class MigrationITest {
     }
   }
 
-  void assertMonacoTextFileEquals(WebElement monacoTabIframe, ExpectedContent file) {
-    var migratedTextFile = getTextFileContent(monacoTabIframe)
+  void assertTextEquals(ExpectedContent file, String filePath) throws IOException {
+    String migratedText = getTextFileContentWithRequest(filePath)
         .replaceAll("\\s", "");
-    var expectedTextFile = new String(file.getContent(), StandardCharsets.UTF_8)
+    String expectedText = new String(file.getContent(), StandardCharsets.UTF_8)
         .replaceAll("\\s", "");
+    compareText(file.getFilePath(), migratedText, expectedText);
+  }
 
-    boolean comparisonResult = expectedTextFile.equals(migratedTextFile);
-    contentComparisons.put(file.getFilePath(), comparisonResult);
+  void assertMonacoTextFileEquals(WebElement monacoTabIframe, ExpectedContent file) {
+    var migratedText = getTextFileContent(monacoTabIframe)
+        .replaceAll("\\s", "");
+    var expectedText = new String(file.getContent(), StandardCharsets.UTF_8)
+        .replaceAll("\\s", "");
+    compareText(file.getFilePath(), migratedText, expectedText);
+  }
+
+  void compareText(String filePath, String migratedText, String expectedTextFile) {
+    boolean comparisonResult = expectedTextFile.equals(migratedText);
+    contentComparisons.put(filePath, comparisonResult);
+
     if(!comparisonResult) {
       System.out.println(
-            "\n"
-          + "[MigrationITest]  Unexpected text file content! "
-          + file.getFilePath()
-          + "\n Expected: \n"
-          + expectedTextFile
-          + "\n Actual: \n"
-          + migratedTextFile + "\n"
+          "\n"
+              + "[MigrationITest]  Unexpected text file content! "
+              + filePath
+              + "\n Expected: \n"
+              + expectedTextFile
+              + "\n Actual: \n"
+              + migratedText + "\n"
       );
     }
   }
-
   private byte[] getImageFileContent(String filePath, WebElement imageTabIframe) throws IOException {
     webBrowser.switchToDefaultContent();
     webBrowser.switchToIframe(imageTabIframe);
@@ -335,6 +351,27 @@ public class MigrationITest {
       );
       webBrowser.switchToDefaultContent();
       return EntityUtils.toByteArray(entity);
+    } catch (URISyntaxException | InterruptedException | ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String getTextFileContentWithRequest(String filePath) throws IOException {
+    var textFileUrl = new URL(
+        "http://"
+            + DirigibleConnectionProperties.HOST
+            + ":" + DirigibleConnectionProperties.PORT
+            + "/services/v4/ide/workspaces/"
+            + expectedContentProvider.getExpectedWorkspaceName()
+            + filePath
+    );
+
+    XSKHttpClient client = LocalXSKHttpClient.create(LOCALHOST_URI);
+    try {
+      HttpUriRequest request = RequestBuilder.get(textFileUrl.toURI()).build();
+      var response = client.executeRequestAsync(request).get();
+      HttpEntity entity = response.getEntity();
+      return entity.getContent().toString();
     } catch (URISyntaxException | InterruptedException | ExecutionException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
- Do not use the 'context menu > code editor' option for hdi and csv due to flakiness with the context menu selections
- Log the dropdown items during migration, due to issue with multiple dropdown items being selected, where only one is valid.