### PR TITLE
Fix git distroless

### DIFF
--- a/releng/sap-cf/Dockerfile
+++ b/releng/sap-cf/Dockerfile
@@ -16,6 +16,10 @@ FROM dirigiblelabs/xsk-kyma-runtime-base as base
 
 COPY target/ROOT.war /usr/local/tomcat/webapps/
 
+RUN apt-get update && \
+    apt-get install git -y && \
+    apt-get clean
+
 FROM base AS xsk-external-jdk
 # If JDK_TYPE is set to `external-jdk`, then the JDK_HOME is required and it should point to the home directory of the jdk
 ARG JDK_HOME

--- a/releng/sap-kyma-runtime/Dockerfile-base
+++ b/releng/sap-kyma-runtime/Dockerfile-base
@@ -15,7 +15,7 @@ RUN rm -fr /opt/java/openjdk
 RUN rm -R /usr/local/tomcat/webapps.dist
 RUN rm /usr/local/tomcat/conf/tomcat-users.xml
 RUN apt-get update && \
-    apt-get install wget git -y && \
+    apt-get install wget -y && \
     apt-get clean
 
 RUN wget https://repo1.maven.org/maven2/com/sap/cloud/db/jdbc/ngdbc/2.8.12/ngdbc-2.8.12.jar -P /usr/local/tomcat/lib/
@@ -25,6 +25,5 @@ RUN mkdir -p /usr/local/tomcat/target/dirigible/repository/root/registry/public/
 FROM sapmachine:17.0.2 as jdk
 
 COPY --from=base /usr/local/tomcat /usr/local/tomcat
-COPY --from=base /usr/bin/git /usr/bin/git
 RUN ln -s /usr/lib/jvm/sapmachine-17/ /usr/local/jdk
 

--- a/releng/sap-kyma/Dockerfile
+++ b/releng/sap-kyma/Dockerfile
@@ -16,6 +16,10 @@ FROM dirigiblelabs/xsk-kyma-runtime-base as base
 
 COPY target/ROOT.war /usr/local/tomcat/webapps/
 
+RUN apt-get update && \
+    apt-get install git -y && \
+    apt-get clean
+
 FROM base AS xsk-external-jdk
 # If JDK_TYPE is set to `external-jdk`, then the JDK_HOME is required and it should point to the home directory of the jdk
 ARG JDK_HOME

--- a/releng/server/Dockerfile
+++ b/releng/server/Dockerfile
@@ -10,6 +10,10 @@ COPY target/ROOT.war /usr/local/tomcat/webapps/
 
 RUN wget --no-check-certificate https://www.dirigible.io/help/conf/tomcat-users.xml -P /usr/local/tomcat/conf/
 
+RUN apt-get update && \
+    apt-get install git -y && \
+    apt-get clean
+
 FROM base AS xsk-external-jdk
 # If JDK_TYPE is set to `external-jdk`, then the JDK_HOME is required and it should point to the home directory of the jdk
 ARG JDK_HOME


### PR DESCRIPTION
Now when you run `git` return:
`git: ldd --verbose /lib/x86_64-linux-gnu/libc.so.6: version not found (required by git)`

**Changed**

* Removed git installation from base `dirigiblelabs/xsk-kyma-runtime-base` and added to every releng Dockerfile.
