### PR TITLE
Change default autocommit mode for $.db.Connection and $.hdb.Connection

### DIFF
--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/db/db.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/db/db.js
@@ -209,6 +209,8 @@ function XscCallableStatement(callableStatement) {
 }
 
 function XscConnection(dConnection) {
+	dConnection.setAutoCommit(false);
+	
 	this.close = function () {
 		dConnection.close();
 	};

--- a/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/hdb/hdb.js
+++ b/modules/api/api-xsjs/src/main/resources/META-INF/dirigible/xsk/hdb/hdb.js
@@ -29,6 +29,8 @@ exports.ProcedureResult = function () {
 exports.ResultSet = XscResultSet;
 
 function XscConnection(dConnection) {
+	dConnection.setAutoCommit(false);
+	
 	this.close = function () {
 		dConnection.close();
 	};


### PR DESCRIPTION
Default auto commit mode for $.db.Connection and $.hdb.Connection changed to false as it is in XSC