### PR TITLE
XSK-Helm-chart-improve-pvc

### DIFF
--- a/releng/helm-charts/xsk/templates/xsk.yaml
+++ b/releng/helm-charts/xsk/templates/xsk.yaml
@@ -90,8 +90,8 @@ spec:
           imagePullPolicy: {{ required "Missing application image pull policy" .Values.application.imagePullPolicy }}
           {{- if .Values.persistentVolumeClaim.enabled }}
           volumeMounts:
-          - name: {{ required "Missing volume mounts name" .Values.deployment.volumeMountsName }}
-            mountPath: {{ required "Missing volume mounts path" .Values.deployment.volumeMountsMountPath }}
+          - name: {{ required "Missing volume mounts name" .Values.deployment.volumesName }}
+            mountPath: {{ required "Missing volume mounts path" .Values.deployment.volumeMountPath }}
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -126,14 +126,14 @@ spec:
       volumes:
       - name: {{ required "Missing volume mounts name" .Values.deployment.volumesName }}
         persistentVolumeClaim:
-          claimName: {{ required "Missing volume mounts name" .Values.deployment.volumespersistentVolumeClaimClaimName }}
+          claimName: {{ default .Release.Name .Values.persistentVolumeClaim.name }}-claim
       {{- end }}
 ---
 {{- if .Values.persistentVolumeClaim.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ required "Missing persistent volume claim name" .Values.persistentVolumeClaim.name }}
+  name: {{ default .Release.Name .Values.persistentVolumeClaim.name }}-claim
 spec:
   accessModes:
   - {{ required "Missing persistent volume claim access mode" .Values.persistentVolumeClaim.accessModes }}

--- a/releng/helm-charts/xsk/values.yaml
+++ b/releng/helm-charts/xsk/values.yaml
@@ -17,10 +17,8 @@ deployment:
   LivenessProbeInitialDelaySeconds: 60
   LivenessProbeHttpGetPort: 8080
   # Volume mounts for the deployment
-  volumeMountsName: xsk-volume
-  volumeMountsMountPath: /usr/local/tomcat/target/dirigible/repository
+  volumeMountPath: /usr/local/tomcat/target/dirigible/repository
   volumesName: xsk-volume
-  volumespersistentVolumeClaimClaimName: xsk-claim
   # Resource limits
   resourcesEnabled: 
   resourcesRequestsMemory: "2Gi"
@@ -30,7 +28,7 @@ deployment:
 
 persistentVolumeClaim:
   enabled: true
-  name: xsk-claim
+  name: 
   accessModes: ReadWriteOnce
   resourcesStorage: 1Gi
 


### PR DESCRIPTION
**Description**

* This will solve the problem if you have two or more XSK deployments with pvc in one namespace without changing the pvc name. 

**Changed**

* set the default name for `pvc` from release name. 

**Removed**

* `.Values.deployment.volumeMountsName` will be using `.Values.deployment.volumesName`
* `.Values.volumespersistentVolumeClaimClaimName` will be using `.Values.persistentVolumeClaim.name`